### PR TITLE
textViewDidProgrammaticallyUpdate concept introduced to HKWTextView c…

### DIFF
--- a/Hakawai/Core/HKWControlFlowPluginProtocols.h
+++ b/Hakawai/Core/HKWControlFlowPluginProtocols.h
@@ -42,6 +42,11 @@
  */
 - (void)singleLineViewportTapped;
 
+/*!
+ If available, this method is called when the text view is programatically updated (e.g. setText: or setAttributedText:)
+ */
+-(void) textViewDidProgrammaticallyUpdate:(UITextView *)textView;
+
 @end
 
 @protocol HKWAbstractionLayerControlFlowPluginProtocol <HKWAbstractionLayerDelegate, HKWSimplePluginProtocol>
@@ -58,6 +63,11 @@
  and the user tapped on the text view somewhere.
  */
 - (void)singleLineViewportTapped;
+
+/*!
+ If available, this method is called when the text view is programatically updated (e.g. setText: or setAttributedText:)
+ */
+-(void) textViewDidProgrammaticallyUpdate:(UITextView *)textView;
 
 // UITextViewDelegate optional helper methods
 - (BOOL)textViewShouldBeginEditing:(UITextView *)textView;

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -87,6 +87,13 @@
 - (void)removeSimplePluginNamed:(NSString *)name;
 
 
+/*!
+ Inform the the textview that it was programatically updated (e.g. setText: or setAttributedText:) so that associated
+ plugins can update their state accordingly.
+ */
+-(void) textViewDidProgrammaticallyUpdate;
+
+
 #pragma mark - API (plug-in status)
 
 /*!

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -214,6 +214,15 @@
     }
 }
 
+-(void) textViewDidProgrammaticallyUpdate {
+    
+    if ([self.controlFlowPlugin respondsToSelector:@selector(textViewDidProgrammaticallyUpdate:)]) {
+        [self.controlFlowPlugin textViewDidProgrammaticallyUpdate:self];
+    }
+    else if ([self.abstractionControlFlowPlugin respondsToSelector:@selector(textViewDidProgrammaticallyUpdate:)]) {
+        [self.abstractionControlFlowPlugin textViewDidProgrammaticallyUpdate:self];
+    }
+}
 
 #pragma mark - UITextViewDelegate
 

--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -272,6 +272,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsPluginState) {
 #pragma mark - API
 
 /*!
+ Inform the plugin that the textview was programatically updated (e.g. setText: or setAttributedText:)
+ */
+-(void) textViewDidProgrammaticallyUpdate:(UITextView *)textView;
+
+/*!
  Extract mentions attributes from an attributed string. The array of mentions attribute objects returned by this method
  can be passed directly into the \c addMentions: method on the plug-in.
  */

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1314,6 +1314,17 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 
 #pragma mark - Plug-in protocol
 
+-(void) textViewDidProgrammaticallyUpdate:(UITextView *)textView {
+    if (self.state == HKWMentionsStartDetectionStateCreatingMention) {
+        [self.creationStateMachine cancelMentionCreation];
+    } else {
+       self.state = HKWMentionsStateQuiescent;
+    }
+
+    [self.startDetectionStateMachine resetStateUsingString:[textView.text copy]];
+    [self resetAuxiliaryState];
+}
+
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     BOOL returnValue = YES;
     self.suppressSelectionChangeNotifications = YES;

--- a/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
@@ -51,6 +51,25 @@ typedef NS_ENUM(NSInteger, HKWMentionsStartDetectionState) {
     return sm;
 }
 
+-(void) resetStateUsingString:(NSString *)string {
+
+    self.state = HKWMentionsStartDetectionStateQuiescentReady;
+    self.charactersSinceLastWhitespace = 0;
+    
+    if (!string || string.length == 0) {
+        self.stringBuffer = [@"" mutableCopy];
+        
+    } else {
+        self.stringBuffer = [string mutableCopy];
+        
+        NSRange lastWhitespaceRange = [self.stringBuffer rangeOfCharacterFromSet:[NSCharacterSet whitespaceCharacterSet] options:NSBackwardsSearch];
+        if (lastWhitespaceRange.location != NSNotFound && NSMaxRange(lastWhitespaceRange) <= self.stringBuffer.length) {
+            self.charactersSinceLastWhitespace = self.stringBuffer.length - NSMaxRange(lastWhitespaceRange);
+        }
+    }
+    
+}
+
 - (void)validStringInserted:(NSString *)string
                  atLocation:(NSUInteger)location
       usingControlCharacter:(BOOL)usingControlCharacter

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -120,4 +120,9 @@
  */
 - (void)mentionCreationResumed;
 
+/*!
+ Inform the state machine that the attached control view has reset it's state, and now represents the specified string
+ */
+-(void) resetStateUsingString:(NSString *)string;
+
 @end


### PR DESCRIPTION
This introduces the `textViewDidProgrammaticallyUpdate` concept elsewhere within this module to the HKWTextView class itself, allowing associated plugins to update their state accordingly.

This is a solution candidate for issue #17 where programatic updates via e.g. `setText:` or `setAttributedText:` leave the state machine in a volatile state.