### PR TITLE
Hakawai: Adding functions to HKWMentionsStateChangeDelegate protocol

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -120,6 +120,22 @@ typedef NS_ENUM(NSInteger, HKWMentionsPluginState) {
         createdMention:(id<HKWMentionsEntityProtocol>)entity
             atLocation:(NSUInteger)location;
 
+/*!
+ Inform the delegate that the specified mentions plug-in trimmed a mention at the given location as a result of user
+ input.
+ */
+- (void)mentionsPlugin:(HKWMentionsPlugin *)plugin
+        trimmedMention:(id<HKWMentionsEntityProtocol>)entity
+            atLocation:(NSUInteger)location;
+
+/*!
+ Inform the delegate that the specified mentions plug-in deleted a mention at the given location as a result of user
+ input.
+ */
+- (void)mentionsPlugin:(HKWMentionsPlugin *)plugin
+        deletedMention:(id<HKWMentionsEntityProtocol>)entity
+            atLocation:(NSUInteger)location;
+
 @end
 
 /*!

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -998,6 +998,9 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                                           }];
                 [self stripCustomAttributesFromTypingAttributes];
                 self.parentTextView.selectedRange = NSMakeRange(locationAfterDeletion, 0);
+
+				// Store current mention before reset
+				HKWMentionsAttribute *currentMention = self.currentlySelectedMention;
                 [self resetCurrentMentionsData];
                 self.state = HKWMentionsStateQuiescent;
                 // Update selection state
@@ -1022,7 +1025,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 location = locationAfterDeletion;
                 // Notify the plugin's state change delegate that a mention was deleted.
                 if ([self.stateChangeDelegate respondsToSelector:@selector(mentionsPlugin:deletedMention:atLocation:)]) {
-                    [self.stateChangeDelegate mentionsPlugin:self deletedMention:self.currentlySelectedMention atLocation:location];
+                    [self.stateChangeDelegate mentionsPlugin:self deletedMention:currentMention atLocation:location];
                 }
 
                 // Notify the parent text view's external delegate that the text changed, since a mention was deleted.

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -975,6 +975,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                                                                 0);
                 location = self.parentTextView.selectedRange.location;
 
+                // Notify the plugin's state change delegate that a mention was trimmed.
+                if ([self.stateChangeDelegate respondsToSelector:@selector(mentionsPlugin:trimmedMention:atLocation:)]) {
+                    [self.stateChangeDelegate mentionsPlugin:self trimmedMention:self.currentlySelectedMention atLocation:location];
+                }
                 // Notify the parent text view's external delegate that the text changed, since a mention was trimmed.
                 if (self.notifyTextViewDelegateOnMentionTrim
                     && [self.parentTextView.externalDelegate respondsToSelector:@selector(textViewDidChange:)]) {
@@ -1014,7 +1018,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                         self.currentlySelectedMentionRange = mentionRange;
                         self.state = HKWMentionsStateAboutToSelectMention;
                     }
-                    location = locationAfterDeletion;
+                }
+                location = locationAfterDeletion;
+                // Notify the plugin's state change delegate that a mention was deleted.
+                if ([self.stateChangeDelegate respondsToSelector:@selector(mentionsPlugin:deletedMention:atLocation:)]) {
+                    [self.stateChangeDelegate mentionsPlugin:self deletedMention:self.currentlySelectedMention atLocation:location];
                 }
 
                 // Notify the parent text view's external delegate that the text changed, since a mention was deleted.


### PR DESCRIPTION
- Adding the following functions to HKWMentionsStateChangeDelegate protocol:
1. mentionsPlugin:(HKWMentionsPlugin *)plugin trimmedMention:(id<HKWMentionsEntityProtocol>)entity
   atLocation:(NSUInteger)location
2. mentionsPlugin:(HKWMentionsPlugin *)plugin deletedMention:(id<HKWMentionsEntityProtocol>)entity
   atLocation:(NSUInteger)location