### PR TITLE
Hakawai: FEEDUI-12763, Fixed assertion failure.

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1275,8 +1275,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 // No mention
                 [self resetCurrentMentionsData];
                 self.state = HKWMentionsStateQuiescent;
-                [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingChar];
             }
+            [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingChar];
             break;
         }
         case HKWMentionsStateSelectedMention: {


### PR DESCRIPTION
Repro steps:
1) Add mention at beginning.
2) After the mention, add white space then 3 chars (i.e " aaa").
3) Tap on mention, type a character in the range of first 3 characters.
(You may need to move cursor position by dragging to reach at the specified location).
4) App will crash.

Fix:
- When user change the cursor position by tapping, implicit-mention's buffer string
was not being cleared when new cursor position lies in the range of mention or
just after mention.
- It resulted in an assertion failure "Logic error: prefixLength would make the location of the
mention negative".
- Fixed it by using cursorMovedWithCharacterNowPrecedingCursor() even when tapped on mention
or just after mention. It ultimately clears the implicit-mention's buffer.