### PR TITLE
Fixing a debug device build warning for unsafe usage of UInteger

### DIFF
--- a/Hakawai/Core/HKWTextView+Plugins.m
+++ b/Hakawai/Core/HKWTextView+Plugins.m
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, HKWCycleFirstResponderMode) {
 
     UITextPosition *p = [self positionFromPosition:self.beginningOfDocument offset:self.selectedRange.location];
     NSAssert(p != nil, @"Text position from %@, offset %ld returned nil. This should never happen.",
-             self.beginningOfDocument, self.selectedRange.location);
+             self.beginningOfDocument, (unsigned long)self.selectedRange.location);
     CGRect caretRect = [self caretRectForPosition:p];
 
     CGFloat offsetY = 0;


### PR DESCRIPTION
 Fixing a debug device build warning for unsafe usage of UInteger as a format argument.