### PR TITLE
Adds new public initializers + Swift 3.0

### DIFF
--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -39,6 +39,10 @@
  */
 @interface HKWTextView : UITextView
 
+#pragma mark - Initialization
+
+- (instancetype _Nonnull)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer;
+- (instancetype _Nonnull)initWithFrame:(CGRect)frame;
 
 #pragma mark - API (text view delegate)
 

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -29,6 +29,22 @@
 
 #pragma mark - Lifecycle
 
+- (instancetype)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer {
+    HKWLayoutManager *manager = [HKWLayoutManager new];
+    NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(frame.size.width, FLT_MAX)];
+    container.widthTracksTextView = YES;
+    container.heightTracksTextView = NO;
+    [manager addTextContainer:container];
+    NSTextStorage *storage = [[NSTextStorage alloc] initWithAttributedString:self.attributedText];
+    [storage addLayoutManager:manager];
+
+    self = [super initWithFrame:frame textContainer:container];
+    if (self) {
+        [self setup];
+    }
+    return self;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame {
     HKWLayoutManager *manager = [HKWLayoutManager new];
     NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(frame.size.width, FLT_MAX)];

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -29,7 +29,7 @@
 
 #pragma mark - Lifecycle
 
-- (instancetype)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer {
+- (instancetype _Nonnull)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer {
     HKWLayoutManager *manager = [HKWLayoutManager new];
     NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(frame.size.width, FLT_MAX)];
     container.widthTracksTextView = YES;
@@ -45,7 +45,7 @@
     return self;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame {
+- (instancetype _Nonnull)initWithFrame:(CGRect)frame {
     HKWLayoutManager *manager = [HKWLayoutManager new];
     NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(frame.size.width, FLT_MAX)];
     container.widthTracksTextView = YES;

--- a/HakawaiDemo/HakawaiDemo.xcodeproj/project.pbxproj
+++ b/HakawaiDemo/HakawaiDemo.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 				TargetAttributes = {
 					E1562B9A19E72A6F00D68787 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -404,6 +405,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HakawaiDemo/HakawaiDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -425,6 +427,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HakawaiDemo/HakawaiDemo-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/HakawaiDemo/HakawaiDemo/SimpleChooserView.swift
+++ b/HakawaiDemo/HakawaiDemo/SimpleChooserView.swift
@@ -12,12 +12,12 @@ import UIKit
 class SimpleChooserView : UIView, UIPickerViewDataSource, UIPickerViewDelegate, HKWChooserViewProtocol {
 
     weak var delegate: HKWCustomChooserViewDelegate? = nil
-    var borderMode : HKWChooserBorderMode = .Top
+    var borderMode : HKWChooserBorderMode = .top
 
     // Protocol factory method
     @objc(chooserViewWithFrame:delegate:)
-    class func chooserViewWithFrame(frame: CGRect, delegate: HKWCustomChooserViewDelegate) -> AnyObject {
-        let item = NSBundle.mainBundle().loadNibNamed("SimpleChooserView", owner: nil, options: nil)[0] as! SimpleChooserView
+    class func chooserView(withFrame frame: CGRect, delegate: HKWCustomChooserViewDelegate) -> AnyObject {
+        let item = Bundle.main.loadNibNamed("SimpleChooserView", owner: nil, options: nil)?[0] as! SimpleChooserView
         item.delegate = delegate
         item.frame = frame
         item.setNeedsLayout()
@@ -35,20 +35,20 @@ class SimpleChooserView : UIView, UIPickerViewDataSource, UIPickerViewDelegate, 
     }
 
     func becomeVisible() {
-        hidden = false
+        isHidden = false
         setNeedsLayout()
     }
 
     func resetScrollPositionAndHide() {
         // Don't do anything
-        hidden = true
+        isHidden = true
     }
 
     @IBOutlet weak var pickerView: UIPickerView!
 
-    @IBAction func chooseButtonTapped(sender: UIButton) {
-        let idx = pickerView.selectedRowInComponent(0)
-        delegate?.modelObjectSelectedAtIndex(idx)
+    @IBAction func chooseButtonTapped(_ sender: UIButton) {
+        let idx = pickerView.selectedRow(inComponent: 0)
+        delegate?.modelObjectSelected(at: idx)
     }
 
     // Reload the data
@@ -58,16 +58,16 @@ class SimpleChooserView : UIView, UIPickerViewDataSource, UIPickerViewDelegate, 
 
     // MARK: Picker view delegate and data source
 
-    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String! {
-        let model = delegate?.modelObjectForIndex(row) as! HKWMentionsEntityProtocol
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String! {
+        let model = delegate?.modelObject(for: row) as! HKWMentionsEntityProtocol
         return model.entityName()
     }
 
-    func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
 
-    func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         return delegate?.numberOfModelObjects() ?? 0
     }
 }


### PR DESCRIPTION
Upgrades demo to Swift 3.0 so we can build with 8.3.2. Also exposes `init(frame:)` and `init(frame:textContainer:)` publicly so they can be overridden in subclasses.