### PR TITLE
Fixed bug with 3DTouch Keyboard selection.

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1320,7 +1320,6 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     if (searchRange.location == NSNotFound) {
         searchRange = NSMakeRange(location, 0);
     }
-    [self toggleAutocorrectAsRequiredForRange:searchRange];
 }
 
 


### PR DESCRIPTION
This bug occurs because to change `autocapitalizationType` needs call `resignFirstResponder` and `becomeFirstResponder`, when 3DTouch selecting is working and plugin call `resignFirstResponder` the method `setCursorPosition` send to window first responder, then crash app.

I removed the line `[self toggleAutocorrectAsRequiredForRange:searchRange];` to don't change `autocapitalizationType` when selecting and all funcionalities still works.

See #33 