### PR TITLE
Fix mentions not working when caret is put at the beginning position in some cases

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1248,7 +1248,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStateQuiescent: {
             NSRange mentionRange;
             HKWMentionsAttribute *precedingMention = nil;
-            if (location > 0) {
+            if (location >= 0) {
                 // Look for a preceding mention, but only if we're at the beginning of the text range
                 precedingMention = [self mentionAttributePrecedingLocation:location
                                                                      range:&mentionRange];


### PR DESCRIPTION
Reproduce steps:
1. Input " some text"(with one leading space but no trailing spaces) in the text view.
2. Press <kbd>ctrl</kbd>+<kbd>a</kbd> to put the caret at the beginning of the line.
3. Press <kbd>@</kbd> to trigger a mention. It doesn't work.
4. Press <kbd>Right</kbd> and <kbd>Left</kbd> and <kbd>@</kbd> again. It works this time.

There can't be a preceding mention when `location` is zero but we shouldn't return early because this call `[self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingChar]` is necessary here to update the internal states of `startDetectionStateMachine`.