### PR TITLE
Target Specta pod at Xcode8 branch

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,6 @@ target "Hakawai" do
 end
 
 target "HakawaiTests" do
-  pod 'Specta' 
-  pod 'Expecta'
+  pod 'Specta', :git => 'https://github.com/specta/specta.git', :branch => 'xcode_8'
+  pod 'Expecta', :git => 'https://github.com/specta/expecta.git'
 end
-


### PR DESCRIPTION
Specta master branch does not work with xcode8, but demo app requires it. I've pointed the podfile to the xcode8 compatible branch on github.