### PR TITLE
Fix crash in HKWLayoutManager, added unit tests for LayoutManager and MentionsPlugin

### DIFF
--- a/Hakawai.xcodeproj/project.pbxproj
+++ b/Hakawai.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C65FBC81F607DEB004A9CB4 /* HKWLayoutManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C65FBC61F607DEB004A9CB4 /* HKWLayoutManagerTests.m */; };
+		9C65FBC91F607DEB004A9CB4 /* HKWMentionsPluginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C65FBC71F607DEB004A9CB4 /* HKWMentionsPluginTests.m */; };
 		D923C7A86BAE4140B98CE674 /* libPods-HakawaiTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA135592875A450893230734 /* libPods-HakawaiTests.a */; };
 		E11DF8D119EC8DA30072F4AD /* HKWTextView+TextTransformation.m in Sources */ = {isa = PBXBuildFile; fileRef = E11DF8D019EC8DA30072F4AD /* HKWTextView+TextTransformation.m */; };
 		E1233BFC19A303620052217A /* HKWTextViewPluginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E1233BFB19A303620052217A /* HKWTextViewPluginTests.m */; };
@@ -63,6 +65,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9C65FBC61F607DEB004A9CB4 /* HKWLayoutManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HKWLayoutManagerTests.m; sourceTree = "<group>"; };
+		9C65FBC71F607DEB004A9CB4 /* HKWMentionsPluginTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HKWMentionsPluginTests.m; sourceTree = "<group>"; };
 		ADAD3A835F36586553D39C04 /* Pods-HakawaiTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HakawaiTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HakawaiTests/Pods-HakawaiTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C6EA852D0C609CF4B630BAD3 /* Pods-HakawaiTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HakawaiTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-HakawaiTests/Pods-HakawaiTests.release.xcconfig"; sourceTree = "<group>"; };
 		DA135592875A450893230734 /* libPods-HakawaiTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HakawaiTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -299,6 +303,8 @@
 		E1C9677519A2A66000A4AA93 /* HakawaiTests */ = {
 			isa = PBXGroup;
 			children = (
+				9C65FBC61F607DEB004A9CB4 /* HKWLayoutManagerTests.m */,
+				9C65FBC71F607DEB004A9CB4 /* HKWMentionsPluginTests.m */,
 				E1233BFB19A303620052217A /* HKWTextViewPluginTests.m */,
 				E1D5501919A2F479001DCF1F /* HKWTextViewAutoXTests.m */,
 				E1D5501619A2EDF9001DCF1F /* HKWTextViewExtrasTests.m */,
@@ -489,6 +495,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C65FBC81F607DEB004A9CB4 /* HKWLayoutManagerTests.m in Sources */,
+				9C65FBC91F607DEB004A9CB4 /* HKWMentionsPluginTests.m in Sources */,
 				E1233C0919A3C6680052217A /* HKWTextViewAttributeTransformerTests.m in Sources */,
 				E1DC1F8D19A2D38B00BCF8C7 /* HKWTextViewTextTransformerTests.m in Sources */,
 				E1D5501719A2EDF9001DCF1F /* HKWTextViewExtrasTests.m in Sources */,

--- a/Hakawai/Core/TextKit/HKWLayoutManager.m
+++ b/Hakawai/Core/TextKit/HKWLayoutManager.m
@@ -90,8 +90,17 @@ typedef NSMutableArray RectValuesBuffer;
     if (!textStorage || range.location == NSNotFound) {
         return nil;
     }
+
+    // Avoid out of bounds crashes that can happen when typing in languages like Tamil
+    NSRange adjustedRange;
+    if (range.location + range.length > textStorage.length) {
+        adjustedRange = NSMakeRange(range.location, textStorage.length - range.location);
+    } else {
+        adjustedRange = range;
+    }
+
     // Go through the attributes in the given range and pick out the ones that correspond to the
-    [textStorage enumerateAttributesInRange:range
+    [textStorage enumerateAttributesInRange:adjustedRange
                                     options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                                  usingBlock:^(NSDictionary *attrs, NSRange range, BOOL *stop) {
                                      for (NSString *attr in attrs) {

--- a/HakawaiTests/HKWLayoutManagerTests.m
+++ b/HakawaiTests/HKWLayoutManagerTests.m
@@ -1,0 +1,49 @@
+//
+//  HKWMLayoutManagerTests.m
+//  Hakawai
+//
+//  Created by Matthew Schouest on 9/5/17.
+//  Copyright (c) 2017 LinkedIn Corp. All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+
+#define EXP_SHORTHAND
+
+#import "Specta.h"
+#import "Expecta.h"
+
+#import "HKWTextView.h"
+#import "_HKWLayoutManager.h"
+
+@interface HKWLayoutManager ()
+- (NSArray *)roundedRectBackgroundAttributeTuplesInTextStorage:(NSTextStorage *)textStorage
+                                                   withinRange:(NSRange)range;
+@end
+
+SpecBegin(layoutManager)
+
+describe(@"roundedRectBackgroundAttributeTuples method", ^{
+    __block HKWTextView *textView;
+    __block HKWLayoutManager *layoutManager;
+    NSString *baseString = @"The quick brown fox jumps over the lazy dog";
+
+    beforeEach(^{
+        textView = [[HKWTextView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+        textView.attributedText = [[NSAttributedString alloc] initWithString:baseString];
+        layoutManager = (HKWLayoutManager *)textView.layoutManager;
+    });
+
+    it(@"should not crash with with invalid ranges", ^{
+        NSRange range = NSMakeRange(0, 100);
+        NSArray *result = [layoutManager roundedRectBackgroundAttributeTuplesInTextStorage:textView.textStorage withinRange:range];
+        expect(result).notTo.beNil();
+    });
+    
+
+});
+
+SpecEnd

--- a/HakawaiTests/HKWMentionsPluginTests.m
+++ b/HakawaiTests/HKWMentionsPluginTests.m
@@ -1,0 +1,113 @@
+//
+//  HKWMentionsPluginTests.m
+//  Hakawai
+//
+//  Created by Matthew Schouest on 8/17/17.
+//  Copyright (c) 2017 LinkedIn Corp. All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+
+#define EXP_SHORTHAND
+
+#import "Specta.h"
+#import "Expecta.h"
+
+#import "HKWTextView.h"
+#import "HKWMentionsPlugin.h"
+#import "HKWMentionsAttribute.h"
+
+@interface HKWTextView ()
+- (BOOL)textViewShouldBeginEditing:(UITextView *)textView;
+- (void)textViewDidBeginEditing:(UITextView *)textView;
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView;
+- (void)textViewDidEndEditing:(UITextView *)textView;
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)replacementText;
+- (void)textViewDidChange:(UITextView *)textView;
+- (void)textViewDidChangeSelection:(UITextView *)textView;
+- (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange;
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange;
+@end
+
+SpecBegin(mentionPluginsSetup)
+
+describe(@"basic mentions plugin setup", ^{
+    __block HKWTextView *textView;
+
+    beforeEach(^{
+        textView = [[HKWTextView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+    });
+
+    it(@"should properly register and unregister mentions plug-in", ^{
+        HKWMentionsPlugin *plugin = [HKWMentionsPlugin mentionsPluginWithChooserMode:HKWMentionsChooserPositionModeCustomLockTopArrowPointingUp];
+        // Add plug-ins
+        [textView setControlFlowPlugin:plugin];
+        expect([textView controlFlowPlugin]).to.beKindOf(HKWMentionsPlugin.class);
+
+        // Check parentTextView
+        expect(plugin.parentTextView).to.equal(textView);
+
+        // Remove plug-in
+        textView.controlFlowPlugin = nil;
+        expect(textView.controlFlowPlugin).to.beNil;
+        expect(plugin.parentTextView).to.beNil;
+    });
+});
+
+describe(@"inserting and reading mentions", ^{
+    __block HKWTextView *textView;
+    __block HKWMentionsPlugin *mentionsPlugin;
+
+    beforeEach(^{
+        textView = [[HKWTextView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+        mentionsPlugin = [HKWMentionsPlugin mentionsPluginWithChooserMode:HKWMentionsChooserPositionModeCustomLockTopArrowPointingUp];
+        [textView setControlFlowPlugin:mentionsPlugin];
+    });
+
+    it(@"should properly return mentions", ^{
+        HKWMentionsAttribute *m1 = [HKWMentionsAttribute mentionWithText:@"Asdf ghjkl" identifier:@"1"];
+        HKWMentionsAttribute *m2 = [HKWMentionsAttribute mentionWithText:@"Qwerty Uiop" identifier:@"2"];
+
+        expect(mentionsPlugin.mentions.count).to.equal(0);
+
+        [textView insertText:m1.mentionText];
+        m1.range = NSMakeRange(0, 10);
+
+        [mentionsPlugin addMention:m1];
+        expect(mentionsPlugin.mentions.count).to.equal(1);
+
+        [textView insertText:@" "];
+
+        [textView insertText:m2.mentionText];
+        m2.range = NSMakeRange(11, 11);
+        [mentionsPlugin addMention:m2];
+
+        expect(mentionsPlugin.mentions.count).to.equal(2);
+    });
+
+    it(@"should properly handle mentions containing emoji", ^{
+        HKWMentionsAttribute *m1 = [HKWMentionsAttribute mentionWithText:@"Asdf ghjk🐝" identifier:@"1"];
+        HKWMentionsAttribute *m2 = [HKWMentionsAttribute mentionWithText:@"Qwerty👨‍👩‍👧‍👧 Uiop" identifier:@"2"];
+
+        expect(mentionsPlugin.mentions.count).to.equal(0);
+
+        [textView insertText:m1.mentionText];
+        m1.range = NSMakeRange(0, 11);
+
+        [mentionsPlugin addMention:m1];
+        expect(mentionsPlugin.mentions.count).to.equal(1);
+
+        [textView insertText:@" "];
+
+        [textView insertText:m2.mentionText];
+        m2.range = NSMakeRange(12, 25);
+        [mentionsPlugin addMention:m2];
+        
+        expect(mentionsPlugin.mentions.count).to.equal(2);
+    });
+});
+
+SpecEnd

--- a/HakawaiTests/HKWMentionsPluginTests.m
+++ b/HakawaiTests/HKWMentionsPluginTests.m
@@ -20,18 +20,6 @@
 #import "HKWMentionsPlugin.h"
 #import "HKWMentionsAttribute.h"
 
-@interface HKWTextView ()
-- (BOOL)textViewShouldBeginEditing:(UITextView *)textView;
-- (void)textViewDidBeginEditing:(UITextView *)textView;
-- (BOOL)textViewShouldEndEditing:(UITextView *)textView;
-- (void)textViewDidEndEditing:(UITextView *)textView;
-- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)replacementText;
-- (void)textViewDidChange:(UITextView *)textView;
-- (void)textViewDidChangeSelection:(UITextView *)textView;
-- (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange;
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange;
-@end
-
 SpecBegin(mentionPluginsSetup)
 
 describe(@"basic mentions plugin setup", ^{

--- a/HakawaiTests/HKWMentionsPluginTests.m
+++ b/HakawaiTests/HKWMentionsPluginTests.m
@@ -62,7 +62,7 @@ describe(@"inserting and reading mentions", ^{
         expect(mentionsPlugin.mentions.count).to.equal(0);
 
         [textView insertText:m1.mentionText];
-        m1.range = NSMakeRange(0, 10);
+        m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
         expect(mentionsPlugin.mentions.count).to.equal(1);
@@ -70,7 +70,7 @@ describe(@"inserting and reading mentions", ^{
         [textView insertText:@" "];
 
         [textView insertText:m2.mentionText];
-        m2.range = NSMakeRange(11, 11);
+        m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
         [mentionsPlugin addMention:m2];
 
         expect(mentionsPlugin.mentions.count).to.equal(2);
@@ -83,7 +83,7 @@ describe(@"inserting and reading mentions", ^{
         expect(mentionsPlugin.mentions.count).to.equal(0);
 
         [textView insertText:m1.mentionText];
-        m1.range = NSMakeRange(0, 11);
+        m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
         expect(mentionsPlugin.mentions.count).to.equal(1);
@@ -91,9 +91,30 @@ describe(@"inserting and reading mentions", ^{
         [textView insertText:@" "];
 
         [textView insertText:m2.mentionText];
-        m2.range = NSMakeRange(12, 25);
+        m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
         [mentionsPlugin addMention:m2];
         
+        expect(mentionsPlugin.mentions.count).to.equal(2);
+    });
+
+    it(@"should properly handle mentions containing only emoji", ^{
+        HKWMentionsAttribute *m1 = [HKWMentionsAttribute mentionWithText:@"🐝🙅‍♂️ 👨‍👨‍👧👔" identifier:@"1"];
+        HKWMentionsAttribute *m2 = [HKWMentionsAttribute mentionWithText:@"🦎🌘" identifier:@"2"];
+
+        expect(mentionsPlugin.mentions.count).to.equal(0);
+
+        [textView insertText:m1.mentionText];
+        m1.range = NSMakeRange(0, m1.mentionText.length);
+
+        [mentionsPlugin addMention:m1];
+        expect(mentionsPlugin.mentions.count).to.equal(1);
+
+        [textView insertText:@" "];
+
+        [textView insertText:m2.mentionText];
+        m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
+        [mentionsPlugin addMention:m2];
+
         expect(mentionsPlugin.mentions.count).to.equal(2);
     });
 });


### PR DESCRIPTION
The crash can happen when typing in particular languages, like Tamil, when characters combine and result in shorter text afterwards.