### PR TITLE
Fix shouldChangeTextInRange detecting text insertion with CJK input methods

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1382,7 +1382,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             textView.selectedRange = range;
         }
     }
-    else if ([text length] > 1) {
+    else if (range.length == 0 && [text length] > 1) {
         // Inserting text (e.g. pasting)
         returnValue = [self advanceStateForStringInsertionAtRange:range text:text];
     }


### PR DESCRIPTION
This fixes the first issue mentioned in #60.

When the first candidate `test` is confirmed, `shouldChangeTextInRange` is called with text `test` and range `(0, 4)`. However, the text is not changed after confirmation (and after `transformTextAtRange`). So when the return value `NO` tells UIKit to revert this unconfirmed insertion, `test` gets removed. If the user selected another candidate, the text gets inserted successfully in `transformTextAtRange` and reverting will fail because the text is changed.

I rather consider this as a workaround because Hakawai seems never to take CJK input methods(which will insert unconfirmed marked text when the user is typing) into account and the second issue mentioned in #60 is much harder than this to fix without a major refactoring.

Related JIRA ticket: FEEDUI-35334, CHINA-14280