### PR TITLE
Fixes crash when enabling the parentTextView.undoManager if it was already enabled

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -382,8 +382,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 
     // Enable 'undo' if this plug-in is being unregistered
     if (self.shouldEnableUndoUponUnregistration) {
-        [self.parentTextView.undoManager enableUndoRegistration];
+        if(!self.parentTextView.undoManager.isUndoRegistrationEnabled)
+            [self.parentTextView.undoManager enableUndoRegistration];
     }
+    
+    
     // Restore the parent text view's spell checking
     [self.parentTextView restoreOriginalSpellChecking:NO];
 


### PR DESCRIPTION
App was crashing while enabling the `parentTextView.undoManager` if it was already enabled. So I am just checking if it is already enabled.