### PR TITLE
Fix documentation param names to silence Xcode warnings

### DIFF
--- a/Hakawai/Core/HKWTextView+Plugins.h
+++ b/Hakawai/Core/HKWTextView+Plugins.h
@@ -56,8 +56,8 @@ typedef NS_ENUM(NSInteger, HKWAccessoryViewMode) {
  \warning Do not move the text view to a different superview while the text view is in single-line viewport mode; this
  will cause problems.
 
- \param captureTouches    if YES, taps on the text view while in single line viewport mode will not be forwarded to the
-                          text view; instead they will trigger special events (that the plug-in can respond to)
+ \param shouldCaptureTouches    if YES, taps on the text view while in single line viewport mode will not be forwarded
+                                to the text view; instead they will trigger special events (that the plug-in can respond to)
 
  \returns a \c CGRect describing (relative to the editor view's bounds) the rectangle occupied by the single line
           viewport

--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -174,10 +174,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsPluginState) {
  completion block accordingly.
 
  \param keyString          the string that the data source should search upon
- \param searchType         an enum describing the mention type for search purposes; currently, this can be Explicit
+ \param type               an enum describing the mention type for search purposes; currently, this can be Explicit
                            (user typed in control character) or Implicit (user typed in a number of consecutive valid
                            characters)
- \param character          if \c searchType is Explicit, this is the control character that was typed to begin the
+ \param character          if \c type is Explicit, this is the control character that was typed to begin the
                            mention creation; otherwise, it should be ignored
  \param completionBlock    a provided block that must be called upon completion or failure. Pass in an array containing
                            items conforming to the \c HKWMentionsEntityProtocol protocol; these will be used to populate

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -134,7 +134,7 @@
  \param prefix                   a string containing text that the user typed before mentions creation started, but
                                  should be used as a query string for asking the data source for suggestions
  \param usingControlCharacter    whether or not the mention was started by typing a special control character
- \param controlCharacter         if \c usingControlCharacter is NO, this is ignored; otherwise, the control character
+ \param character                if \c usingControlCharacter is NO, this is ignored; otherwise, the control character
                                  used to begin the mention
  \param location                 the index position where the completed mention should begin
  */

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -35,7 +35,7 @@
                                    the prefix (if an implicit mention was created) was fully inserted into the text view
                                    buffer at the time the method was invoked
  \param usingControlCharacter      whether the mention was begun by the user typing a special control character
- \param controlCharacter           if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
+ \param character                  if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
                                    begin the mention
  */
 - (void)beginMentionsCreationWithString:(NSString *)prefix
@@ -52,7 +52,7 @@
  \param location                   the index in the textView which identifies the start of the target string (including
                                    the control char if present)
  \param usingControlCharacter      whether the mention was begun by the user typing a special control character
- \param controlCharacter           if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
+ \param character                  if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
                                    begin the mention
  */
 - (void)beginMentionsCreationWithString:(NSString *)prefix
@@ -79,10 +79,10 @@
  Inform the state machine that a valid string was typed (or pasted, or auto-inserted) by the user into the text view.
  \param string                   the string that is being analyzed in the text view (not including a control character
                                  if one exists)
- \param location                 the text view index of the \c controlCharacter if present, or the start index of the
-                                 \c string if a \c controlCharacter is not present
+ \param location                 the text view index of the \c character if present, or the start index of the \c string
+                                 if a \c character is not present
  \param usingControlCharacter    whether the mention was begun by the user typing a special control character
- \param controlCharacter         if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
+ \param character                if \c usingControlCharacter is NO, ignored; otherwise, the control character used to
                                  begin the mention
  */
 - (void)validStringInserted:(NSString *)string


### PR DESCRIPTION
The warnings for this are disabled in the Hakawai xcodeproj, but consumers of this library don't usually disable these warnings, and I've been seeing several like this about the documentation:
```
.../Pods/Hakawai/Hakawai/Core/HKWTextView+Plugins.h:59:9: Parameter 'captureTouches' not found in the function declaration
```

This PR fixes all those warnings by referring to the correct param name. I suspect that some of these params should actually be renamed to the more descriptive documented name, but I'm just fixing the warnings.