### PR TITLE
Remove usage of sharedApplication to allow Hakawai to be used in App Extensions

### DIFF
--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -520,10 +520,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     // Handle the case where the chooser frame is completely custom
     if ([HKWMentionsCreationStateMachine modeRequiresCustomFrame:mode]) {
         // Placeholder frame; used until the constraints are properly applied
-        chooserFrame = CGRectMake(0,
-                                  0,
-                                  [UIApplication sharedApplication].keyWindow.bounds.size.width,
-                                  100);
+        chooserFrame = CGRectZero;
     }
     NSAssert(!CGRectIsNull(chooserFrame), @"Logic error: got a null rect for the chooser view's frame");
 


### PR DESCRIPTION
This usage of sharedApplication is the only instance of Hakawai using an API not allowed in App Extensions. On top of that, it's unnecessary to use it at all. CGRectZero works just as well here as constraints take over afterwards to correctly size the Chooser view.