### PR TITLE
Adds configuration for shouldContinueSearchingAfterEmptyResults

### DIFF
--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "5.1.4"
+  s.version      = "5.1.5"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "7.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "5.1.4" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "5.1.5" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Hakawai.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -355,6 +355,13 @@ typedef NS_ENUM(NSInteger, HKWMentionsPluginState) {
  */
 @property (nonatomic) BOOL resumeMentionsCreationEnabled;
 
+/*!
+ Whether or not we should continue searching for an explicit mention after we get back empty results. If this
+ is off, empty results will return the mentions creation state to \c HKWMentionsPluginStateQuiescent. If this is
+ on, empty results won't modify the mentions creation state.
+ */
+@property (nonatomic) BOOL shouldContinueSearchingAfterEmptyResults;
+
 
 #pragma mark - Chooser UI Configuration
 

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -27,6 +27,13 @@
 @property (nonatomic, readonly) BOOL loadingCellSupported;
 
 /*!
+ Whether or not we should continue searching for an explicit mention after we get back empty results. If this
+ is off, empty results will return the mentions creation state to \c HKWMentionsPluginStateQuiescent. If this is
+ on, empty results won't modify the mentions creation state.
+ */
+@property (nonatomic, readonly) BOOL shouldContinueSearchingAfterEmptyResults;
+
+/*!
  Request the bounds of the editor text view owning the delegate.
  */
 - (CGRect)boundsForParentEditorView;


### PR DESCRIPTION
This configuration value (off by default) will enable us to change behavior for what happens when we have a query with no results. By default, this returns the mentions state to quiescent, preventing further mentions. With the flag on, we don't cancel the mention and continue searching the next time we delete or add a character.