### PR TITLE
Add support to trigger fetch for initial mention

### DIFF
--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -426,17 +426,17 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     self.searchType = HKWMentionsSearchTypeInitial;
     self.sequenceNumber += 1;
     NSUInteger sequenceNumber = self.sequenceNumber;
-    __weak typeof(self) __self = self;
+    __weak typeof(self) __weakSelf = self;
 
     [self.delegate asyncRetrieveEntitiesForKeyString:@""
                                           searchType:self.searchType
                                     controlCharacter:0
                                           completion:^(NSArray *results, BOOL dedupe, BOOL isComplete) {
-                                              [__self dataReturnedWithResults:results
-                                                               sequenceNumber:sequenceNumber
-                                                                triggerAction:HKWMentionsCreationActionNone
-                                                                dedupeResults:dedupe
-                                                          dataFetchIsComplete:isComplete];
+                                              [__weakSelf dataReturnedWithResults:results
+                                                                   sequenceNumber:sequenceNumber
+                                                                    triggerAction:HKWMentionsCreationActionNone
+                                                                    dedupeResults:dedupe
+                                                              dataFetchIsComplete:isComplete];
                                           }];
 }
 

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -422,6 +422,23 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     return nil;
 }
 
+- (void)fetchInitialMentions {
+    self.searchType = HKWMentionsSearchTypeInitial;
+    self.sequenceNumber += 1;
+    NSUInteger sequenceNumber = self.sequenceNumber;
+    __weak typeof(self) __self = self;
+
+    [self.delegate asyncRetrieveEntitiesForKeyString:@""
+                                          searchType:self.searchType
+                                    controlCharacter:0
+                                          completion:^(NSArray *results, BOOL dedupe, BOOL isComplete) {
+                                              [__self dataReturnedWithResults:results
+                                                               sequenceNumber:sequenceNumber
+                                                                triggerAction:HKWMentionsCreationActionNone
+                                                                dedupeResults:dedupe
+                                                          dataFetchIsComplete:isComplete];
+                                          }];
+}
 
 #pragma mark - Chooser View Frame
 
@@ -645,7 +662,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 (unsigned long)sequence, (unsigned long)self.sequenceNumber);
         return;
     }
-    if (self.state == HKWMentionsCreationStateQuiescent) {
+    if (self.state == HKWMentionsCreationStateQuiescent && self.searchType != HKWMentionsSearchTypeInitial) {
         NSAssert(self.chooserState == HKWMentionsCreationChooserStateHidden,
                  @"Logic error: entity chooser view is active even though state machine is quiescent.");
         self.entityArray = nil;
@@ -703,8 +720,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
     self.entityArray = [validResults copy];
 
-    // If mentions creation is still active and we haven't shown the chooser view, show it now.
-    if (self.state != HKWMentionsCreationStateQuiescent
+    // If mentions creation is still active or if its for initial search, and we haven't shown the chooser view, show it now.
+    if ((self.state != HKWMentionsCreationStateQuiescent || self.searchType == HKWMentionsSearchTypeInitial)
         && self.chooserState == HKWMentionsCreationChooserStateHidden) {
         [self showChooserView];
     }
@@ -802,10 +819,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 
     // Advance the results state. The user could have been in one of two states formally: results existed, or there were
-    //  no results but the user hadn't typed a whitespace character since results stopped coming back
+    //  no results but the user hadn't typed a whitespace character since results stopped coming back, or if the search results are for initial state
     NSAssert((self.delegate.shouldContinueSearchingAfterEmptyResults && self.resultsState == HKWMentionsCreationResultsStateAwaitingFirstResult)
              || self.resultsState == HKWMentionsCreationResultsStateCreatingMentionWithResults
-             || self.resultsState == HKWMentionsCreationResultsStateNoResultsWithoutWhitespace,
+             || self.resultsState == HKWMentionsCreationResultsStateNoResultsWithoutWhitespace
+             || self.searchType == HKWMentionsSearchTypeInitial,
              @"Logic error in dataReturnedForResults:...; resultsState is inconsistent. Got %@, which is invalid.",
              nameForResultsState(self.resultsState));
     self.resultsState = HKWMentionsCreationResultsStateNoResultsWithoutWhitespace;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -426,17 +426,17 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     self.searchType = HKWMentionsSearchTypeInitial;
     self.sequenceNumber += 1;
     NSUInteger sequenceNumber = self.sequenceNumber;
-    __weak typeof(self) __weakSelf = self;
+    __weak typeof(self) weakSelf = self;
 
     [self.delegate asyncRetrieveEntitiesForKeyString:@""
                                           searchType:self.searchType
                                     controlCharacter:0
                                           completion:^(NSArray *results, BOOL dedupe, BOOL isComplete) {
-                                              [__weakSelf dataReturnedWithResults:results
-                                                                   sequenceNumber:sequenceNumber
-                                                                    triggerAction:HKWMentionsCreationActionNone
-                                                                    dedupeResults:dedupe
-                                                              dataFetchIsComplete:isComplete];
+                                              [weakSelf dataReturnedWithResults:results
+                                                                 sequenceNumber:sequenceNumber
+                                                                  triggerAction:HKWMentionsCreationActionNone
+                                                                  dedupeResults:dedupe
+                                                            dataFetchIsComplete:isComplete];
                                           }];
 }
 

--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -76,7 +76,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsChooserPositionMode) {
 
 typedef NS_ENUM(NSInteger, HKWMentionsSearchType) {
     HKWMentionsSearchTypeImplicit,
-    HKWMentionsSearchTypeExplicit
+    HKWMentionsSearchTypeExplicit,
+    HKWMentionsSearchTypeInitial
 };
 
 /*!

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -367,6 +367,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     NSUInteger location = self.parentTextView.selectedRange.location;
     unichar precedingChar = [self.parentTextView characterPrecedingLocation:location];
     [self advanceStateForInsertionChanged:precedingChar location:location];
+    [self.creationStateMachine fetchInitialMentions];
 }
 
 // Delegate method called when the plug-in is unregistered from a text view. Cleans up the state of the text view.

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -166,6 +166,11 @@
 - (void)hideChooserArrow;
 
 /*!
+ Inform the state machine to trigger fetch for initial mentions
+ */
+- (void)fetchInitialMentions;
+
+/*!
  Get the chooser view frame. If the chooser view has not yet been instantiated, returns the nil rectangle.
  */
 - (CGRect)chooserViewFrame;

--- a/HakawaiDemo/HakawaiDemo/MentionsManager.m
+++ b/HakawaiDemo/HakawaiDemo/MentionsManager.m
@@ -73,7 +73,8 @@
 //  us to provide a table view cell corresponding to that entity to be presented to the user.
 - (UITableViewCell *)cellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity
                            withMatchString:(NSString *)matchString
-                                 tableView:(UITableView *)tableView {
+                                 tableView:(UITableView *)tableView
+                               atIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"mentionsCell"];
     if (!cell) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"mentionsCell"];
@@ -97,6 +98,9 @@
                          controlCharacter:(unichar)character
                                completion:(void (^)(NSArray *, BOOL, BOOL))completionBlock {
     if (!completionBlock) {
+        return;
+    }
+    if (type == HKWMentionsSearchTypeInitial) {
         return;
     }
     NSArray *data = self.fakeData;

--- a/HakawaiTests/HKWMentionsCreationStateMachineTest.m
+++ b/HakawaiTests/HKWMentionsCreationStateMachineTest.m
@@ -88,6 +88,11 @@ describe(@"Showing mentions list for explicit search only", ^{
         [textView setText:@"@"];
         expect(mentionsPlugin.creationStateMachine.entityArray.count).to.equal(5);
     });
+
+    it(@"should trigger initial fetch mentions request when text begins editing", ^{
+        [textView.delegate textViewShouldBeginEditing:textView];
+        expect(mentionsPlugin.creationStateMachine.entityArray.count).to.equal(1);
+    });
 });
 
 SpecEnd

--- a/HakawaiTests/Supporting Classes/HKWTDummyMentionsManager.h
+++ b/HakawaiTests/Supporting Classes/HKWTDummyMentionsManager.h
@@ -20,7 +20,7 @@
                          controlCharacter:(unichar)character
                                completion:(void(^)(NSArray *results, BOOL dedupe, BOOL isComplete))completionBlock;
 
-- (UITableViewCell *)cellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity withMatchString:(NSString *)matchString tableView:(UITableView *)tableView;
+- (UITableViewCell *)cellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity withMatchString:(NSString *)matchString tableView:(UITableView *)tableView atIndexPath:(NSIndexPath *)indexPath;
 
 - (CGFloat)heightForCellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity tableView:(UITableView *)tableView;
 

--- a/HakawaiTests/Supporting Classes/HKWTDummyMentionsManager.m
+++ b/HakawaiTests/Supporting Classes/HKWTDummyMentionsManager.m
@@ -18,6 +18,9 @@
                                searchType:(HKWMentionsSearchType)type
                          controlCharacter:(unichar)character
                                completion:(void(^)(NSArray *results, BOOL dedupe, BOOL isComplete))completionBlock {
+    if (type == HKWMentionsSearchTypeInitial) {
+        completionBlock([[NSArray alloc] initWithObjects:[HKWTDummyMentionEntity entityWithName:@"Alan Perlis" entityID:@"1"], nil], YES, YES);
+    }
     NSArray *fakeData = @[[HKWTDummyMentionEntity entityWithName:@"Alan Perlis" entityID:@"1"],
                           [HKWTDummyMentionEntity entityWithName:@"Maurice Wilkes" entityID:@"2"],
                           [HKWTDummyMentionEntity entityWithName:@"Michael Rabin" entityID:@"12"],
@@ -28,7 +31,7 @@
     }
 }
 
-- (UITableViewCell *)cellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity withMatchString:(NSString *)matchString tableView:(UITableView *)tableView {
+- (UITableViewCell *)cellForMentionsEntity:(id<HKWMentionsEntityProtocol>)entity withMatchString:(NSString *)matchString tableView:(UITableView *)tableView atIndexPath:(NSIndexPath *)indexPath  {
     return [[UITableViewCell alloc] init];
 }
 


### PR DESCRIPTION
Added support to trigger a fetch async call when the TextView begins editing for the first time. 
This is to allow implementers to show some initial suggestion for mentions.

Added test case to verify that **MentionManager.asyncRetrieveEntitiesForKeyString** is called with search type **HKWMentionsSearchTypeInitial** when HKWTextView begins editing.