### PR TITLE
Notify external delegate of change after manually inserting text.

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -1095,6 +1095,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 self.previousTextLength = [[self.parentTextView text] length];
 
                 [self.startDetectionStateMachine characterTyped:[text characterAtIndex:0] asInsertedCharacter:YES previousCharacter:precedingChar];
+
+                // Manually notify external delegate that the textView changed
+                if ([self.parentTextView.externalDelegate respondsToSelector:@selector(textViewDidChange:)]) {
+                    [self.parentTextView.externalDelegate textViewDidChange:self.parentTextView];
+                }
                 return NO;
             }
             else if ([self stringValidForMentionsCreation:text]) {
@@ -1117,6 +1122,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                                                           atLocation:location
                                                usingControlCharacter:NO
                                                     controlCharacter:0];
+
+                // Manually notify external delegate that the textView changed
+                if ([self.parentTextView.externalDelegate respondsToSelector:@selector(textViewDidChange:)]) {
+                    [self.parentTextView.externalDelegate textViewDidChange:self.parentTextView];
+                }
                 return NO;
             }
             else {


### PR DESCRIPTION
### Why? 
Currently, `textViewDidChange` delegate calls are being swallowed by programmatic text changes in `advanceStateForStringInsertionAtRange`. This is most problematic when a user is typing emoji or other characters where `text.length != 1`. In my specific use case, typing a single emoji in an `HKWTextView` subclass doesn't notify my `externalDelegate` where I enable a submit button and hide a placeholder text label. This problem is also referenced in  https://github.com/linkedin/Hakawai/issues/53

### Solution
Manually notify the external delegate of a change after programmatically updating the text. By not changing any logic internal to the mention plugin, this should avoid any state machine regressions.