### PR TITLE
ENGAGE-51063: Support Dictation search for entities

### DIFF
--- a/Hakawai/Core/HKWSimplePluginProtocol.h
+++ b/Hakawai/Core/HKWSimplePluginProtocol.h
@@ -45,4 +45,7 @@
 
 @optional
 
+/// This property holds the `string` added in the `HKWTextView` via dictation
+@property (nonatomic, strong, readwrite) NSString *dictationString;
+
 @end

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -151,6 +151,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 
 @synthesize parentTextView = _parentTextView;
 
+@synthesize dictationString;
+
 + (instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode {
     static const NSInteger defaultSearchLength = 3;
     return [self mentionsPluginWithChooserMode:mode
@@ -478,13 +480,18 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 #pragma mark - Private
 
 /*!
- Return whether or not a given string is eligible to be appended to the start detection state machine's buffer. Minimum
- requirements include not containing any whitespace or newline characters.
+ Return whether or not a given string is eligible to be appended to the start detection state machine's buffer.
+ Minimum requirements include not containing any whitespace or newline characters or in case of dication string input.
  */
 - (BOOL)stringValidForMentionsCreation:(NSString *)string {
     if ([string length] == 0) {
         return NO;
     }
+
+    if ([self.dictationString isEqualToString:string]) {
+        return YES;
+    }
+
     NSCharacterSet *invalidChars = [NSCharacterSet whitespaceAndNewlineCharacterSet];
     for (NSUInteger i=0; i<[string length]; i++) {
         unichar c = [string characterAtIndex:i];

--- a/HakawaiTests/HKWMentionsPluginTests.m
+++ b/HakawaiTests/HKWMentionsPluginTests.m
@@ -20,6 +20,10 @@
 #import "HKWMentionsPlugin.h"
 #import "HKWMentionsAttribute.h"
 
+@interface HKWMentionsPlugin ()
+- (BOOL)stringValidForMentionsCreation:(NSString *)string;
+@end
+
 SpecBegin(mentionPluginsSetup)
 
 describe(@"basic mentions plugin setup", ^{
@@ -116,6 +120,30 @@ describe(@"inserting and reading mentions", ^{
         [mentionsPlugin addMention:m2];
 
         expect(mentionsPlugin.mentions.count).to.equal(2);
+    });
+});
+
+describe(@"mentions validation", ^{
+    __block HKWTextView *textView;
+    __block HKWMentionsPlugin *mentionsPlugin;
+
+    beforeEach(^{
+        textView = [[HKWTextView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+        mentionsPlugin = [HKWMentionsPlugin mentionsPluginWithChooserMode:HKWMentionsChooserPositionModeCustomLockTopArrowPointingUp];
+        [textView setControlFlowPlugin:mentionsPlugin];
+    });
+
+    it(@"check the string validation for dictation string", ^{
+        NSString *const mentionString = @"Alan Perkis";
+
+        // Multi word string should not be valid for mentions creation
+        BOOL isStringValid = [mentionsPlugin stringValidForMentionsCreation:mentionString];
+        expect(isStringValid).to.equal(NO);
+
+        // Multi word string should be valid for mentions creation, only if it matches the dictation string
+        [mentionsPlugin setDictationString:mentionString];
+        isStringValid = [mentionsPlugin stringValidForMentionsCreation:mentionString];
+        expect(isStringValid).to.equal(YES);
     });
 });
 

--- a/HakawaiTests/HKWTextViewPluginTests.m
+++ b/HakawaiTests/HKWTextViewPluginTests.m
@@ -38,6 +38,7 @@
 - (void)textViewDidChangeSelection:(UITextView *)textView;
 - (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction;
 - (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction;
+- (void)handleDictationString:(NSString *)dictationString;
 @end
 
 SpecBegin(basicPlugins)
@@ -440,6 +441,34 @@ describe(@"control flow plug-in register/unregister hooks", ^{
         textView.controlFlowPlugin = p1;
         // This test needs a bit of work. It only checks that either of the blocks was called, not both
         expect(rightBlockWasCalled).to.beTruthy();
+    });
+});
+
+SpecEnd
+
+SpecBegin(dictationInput)
+
+describe(@"dictationInput", ^{
+    __block HKWTextView *textView;
+    __block HKWTControlFlowDummyPlugin *mentionsPlugin;
+
+    beforeEach(^{
+        textView = [[HKWTextView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+        mentionsPlugin = [HKWTControlFlowDummyPlugin dummyPluginWithName:@"p1"];
+        [textView setControlFlowPlugin:mentionsPlugin];
+    });
+
+    it(@"insert text should be called for dictation input", ^{
+        __block BOOL rightBlockWasCalled = NO;
+        void (^blockToCall)(void) = ^{
+            rightBlockWasCalled = YES;
+        };
+
+        mentionsPlugin.shouldChangeTextInRangeBlock = blockToCall;
+        [textView handleDictationString:@"Alan Perlis"];
+
+        expect(rightBlockWasCalled).to.equal(YES);
+        expect(textView.text).to.equal(@"Alan Perlis");
     });
 });
 


### PR DESCRIPTION
- Added support to trigger call to fetch entities, when text is inserted via dictation
- Added tests to verify the behavior for dictation
- Fixed an issue in HKWMentionsPlugin.m, which caused a crash when deleting second last character of a string
- Fixed build errors in SimpleChooserView.swift