### PR TITLE
ENGAGE-51063: Support Dictation search for entities

### DIFF
--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -263,7 +263,8 @@
         [self.controlFlowPlugin setDictationString:dictationString];
     }
 
-    if ([self shouldChangeTextInRange:NSMakeRange(self.text.length, 0) replacementText:dictationString isDictationText:YES textView:self]) {
+    // Used selected range to get the cursor position. So that text will be replaced after the cursor.
+    if ([self shouldChangeTextInRange:self.selectedRange replacementText:dictationString isDictationText:YES textView:self]) {
         [self insertText:dictationString];
     }
 }

--- a/HakawaiTests/HKWTextViewPluginTests.m
+++ b/HakawaiTests/HKWTextViewPluginTests.m
@@ -470,6 +470,28 @@ describe(@"dictationInput", ^{
         expect(rightBlockWasCalled).to.equal(YES);
         expect(textView.text).to.equal(@"Alan Perlis");
     });
+
+    it(@"should properly handle mentions for changed cursor position with dictation input", ^{
+        __block BOOL rightBlockWasCalled = NO;
+        void (^blockToCall)(void) = ^{
+            rightBlockWasCalled = YES;
+        };
+
+        mentionsPlugin.shouldChangeTextInRangeBlock = blockToCall;
+        NSString *mentionOneText = @"Alan Perlis";
+        NSString *mentionTwoText = @"Dennis Ritchie";
+        [textView handleDictationString:mentionOneText];
+        expect(rightBlockWasCalled).to.equal(YES);
+        expect(textView.text).to.equal(@"Alan Perlis");
+
+        rightBlockWasCalled = NO;
+        // Simulating the changed cursor position to 8th index in current text where 8 = length of "Alan Per"
+        textView.selectedRange = NSMakeRange(8, 0);
+
+        [textView handleDictationString: mentionTwoText];
+        expect(rightBlockWasCalled).to.equal(YES);
+        expect(textView.text).to.equal(@"Alan PerDennis Ritchielis");
+    });
 });
 
 SpecEnd


### PR DESCRIPTION
- Fixed text insertion point, such that dictation text should be entered after the cursor position and not after the whole text