### PR TITLE
Compares HKWRoundedRectBackgroundAttributeName correctly

### DIFF
--- a/Hakawai/Core/TextKit/HKWLayoutManager.m
+++ b/Hakawai/Core/TextKit/HKWLayoutManager.m
@@ -104,7 +104,7 @@ typedef NSMutableArray RectValuesBuffer;
                                     options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                                  usingBlock:^(NSDictionary *attrs, NSRange attributeRange, __unused BOOL *stop) {
                                      for (NSString *attr in attrs) {
-                                         if (attr == HKWRoundedRectBackgroundAttributeName) {
+                                         if ([attr isEqualToString:HKWRoundedRectBackgroundAttributeName]) {
                                              id const attributeValue = attrs[attr];
                                              if (!attributeValue) {
                                                  NSAssert(NO, @"Internal error");


### PR DESCRIPTION
# The problem

See #75, but `HKWRoundedRectBackgroundAttributeName` breaks in Swift when comparing attrs.

# Solution

It was compared with a `const` string, so when the app and the library used different references, it was problematic. This should fix it by adding a string equality check!

Fixes #75 