### PR TITLE
Better externifies our constants for swift interoperability

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -20,7 +20,7 @@
  An attribute for \c NSAttributedString objects representing a mention. This attribute by itself confers no special
  formatting on its text; the plug-in is responsible for coloring and highlighting text according to the current state.
  */
-static NSString *const HKWMentionAttributeName = @"HKWMentionAttributeName";
+OBJC_EXTERN NSString* _Nonnull const HKWMentionAttributeName;
 
 /*!
  An enum representing supported modes for positioning the chooser view.

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -27,6 +27,8 @@
 
 #import "_HKWMentionsPrivateConstants.h"
 
+NSString* _Nonnull const HKWMentionAttributeName = @"HKWMentionAttributeName";
+
 // Don't confuse this with the public 'HKWMentionsPluginState', which exposes fewer implementation details.
 typedef NS_ENUM(NSInteger, HKWMentionsState) {
     // The user is not creating a mention and not in any of the following states.


### PR DESCRIPTION
# Description of change

Takes all other static strings defined in headers and moves them to the implementation file and exposes them via `OBJC_EXTERN`.

## Motivation/Context

This helps Swift interoperability by only providing one copy of the variable, not two like was previously happening. #107 was the other instance of this already fixed. This PR changes the rest