### PR TITLE
Fix iOS QuickPath keyboard deadlock

### DIFF
--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface HKWTextView : UITextView
 
++ (BOOL) enableExperimentalDeadLockFix;
++ (void) setEnableExperimentalDeadLockFix:(BOOL)enabled;
+
 #pragma mark - Initialization
 
 - (instancetype)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer;

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -25,7 +25,16 @@
 @property (nonatomic, strong) NSMutableDictionary *simplePluginsDictionary;
 @end
 
+static BOOL enableExperimentalDeadLockFix = NO;
+
 @implementation HKWTextView
+
++ (BOOL)enableExperimentalDeadLockFix {
+    return enableExperimentalDeadLockFix;
+}
++ (void)setEnableExperimentalDeadLockFix:(BOOL)enabled {
+    enableExperimentalDeadLockFix = enabled;
+}
 
 #pragma mark - Lifecycle
 

--- a/HakawaiTests/HKWMentionsPluginTests.m
+++ b/HakawaiTests/HKWMentionsPluginTests.m
@@ -69,7 +69,10 @@ describe(@"inserting and reading mentions", ^{
         m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
-        expect(mentionsPlugin.mentions.count).to.equal(1);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(1);
+        });
+        
 
         [textView insertText:@" "];
 
@@ -77,7 +80,9 @@ describe(@"inserting and reading mentions", ^{
         m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
         [mentionsPlugin addMention:m2];
 
-        expect(mentionsPlugin.mentions.count).to.equal(2);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(2);
+        });
     });
 
     it(@"should properly handle mentions containing emoji", ^{
@@ -90,15 +95,19 @@ describe(@"inserting and reading mentions", ^{
         m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
-        expect(mentionsPlugin.mentions.count).to.equal(1);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(1);
+        });
+        
 
         [textView insertText:@" "];
 
         [textView insertText:m2.mentionText];
         m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
         [mentionsPlugin addMention:m2];
-        
-        expect(mentionsPlugin.mentions.count).to.equal(2);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(2);
+        });
     });
 
     it(@"should properly handle mentions containing only emoji", ^{
@@ -111,7 +120,9 @@ describe(@"inserting and reading mentions", ^{
         m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
-        expect(mentionsPlugin.mentions.count).to.equal(1);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(1);
+        });
 
         [textView insertText:@" "];
 
@@ -119,7 +130,9 @@ describe(@"inserting and reading mentions", ^{
         m2.range = NSMakeRange(m1.mentionText.length + 1, m2.mentionText.length);
         [mentionsPlugin addMention:m2];
 
-        expect(mentionsPlugin.mentions.count).to.equal(2);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(2);
+        });
     });
 });
 
@@ -166,18 +179,26 @@ describe(@"deleting and reading mentions", ^{
         m1.range = NSMakeRange(0, m1.mentionText.length);
 
         [mentionsPlugin addMention:m1];
-        expect(mentionsPlugin.mentions.count).to.equal(1);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(mentionsPlugin.mentions.count).to.equal(1);
+        });
 
         // the first attempt to delete mention should select the mention and modify the state. No changes apply to the mention and text
         BOOL deletionResult1 = [mentionsPlugin textView:textView shouldChangeTextInRange:NSMakeRange(m1.mentionText.length-1, 1) replacementText:@""];
-        expect(deletionResult1).to.equal(NO);
-        expect(mentionsPlugin.mentions.count).to.equal(1);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(deletionResult1).to.equal(NO);
+            expect(mentionsPlugin.mentions.count).to.equal(1);
+        });
+        
 
         // the second attempt deletes the whole mention
         BOOL deletionResult2 = [mentionsPlugin textView:textView shouldChangeTextInRange:NSMakeRange(m1.mentionText.length-1, 1) replacementText:@""];
-        expect(deletionResult2).to.equal(NO);
-        expect(mentionsPlugin.mentions.count).to.equal(0);
-        expect([textView.text length]).to.equal(0);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(deletionResult2).to.equal(NO);
+            expect(mentionsPlugin.mentions.count).to.equal(0);
+            expect([textView.text length]).to.equal(0);
+        });
+        
 
     });
 });

--- a/HakawaiTests/HKWTextViewAttributeTransformerTests.m
+++ b/HakawaiTests/HKWTextViewAttributeTransformerTests.m
@@ -220,7 +220,9 @@ describe(@"stripAttributeFromTextAtRange API", ^{
         for (NSUInteger i=0; i<baseLength; i++) {
             id observedValue = [textView.attributedText attribute:attributeName atIndex:i effectiveRange:NULL];
             if (i >= stripLocation && i < stripLocation + stripLength) {
-                expect(observedValue).to.equal(nil);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    expect(observedValue).to.equal(nil);
+                });
             }
             else {
                 expect(observedValue).to.equal(attributeValue);

--- a/HakawaiTests/HKWTextViewTextTransformerTests.m
+++ b/HakawaiTests/HKWTextViewTextTransformerTests.m
@@ -33,21 +33,28 @@ describe(@"transformTextAtRange with plain text", ^{
         [textView transformTextAtRange:NSMakeRange(0, 3) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"#### TEST ####"];
         }];
-        expect(textView.text).to.equal(@"#### TEST #### quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"#### TEST #### quick brown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly transform text in middle", ^{
         [textView transformTextAtRange:NSMakeRange(5, 12) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"blah_string"];
         }];
-        expect(textView.text).to.equal(@"The qblah_stringox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The qblah_stringox jumps over the lazy dog");
+        });
+        
     });
 
     it(@"should properly transform text at end", ^{
         [textView transformTextAtRange:NSMakeRange(31, 12) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"a fat bear"];
         }];
-        expect(textView.text).to.equal(@"The quick brown fox jumps over a fat bear");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The quick brown fox jumps over a fat bear");
+        });
     });
 
     it(@"should properly ignore ranges whose beginnings are out of range", ^{
@@ -61,7 +68,9 @@ describe(@"transformTextAtRange with plain text", ^{
         [textView transformTextAtRange:NSMakeRange(10, 1000) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"~~~~ !!!! ~~~~"];
         }];
-        expect(textView.text).to.equal(@"The quick ~~~~ !!!! ~~~~");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The quick ~~~~ !!!! ~~~~");
+        });
     });
 
     it(@"should properly add text to an empty text view", ^{
@@ -70,14 +79,18 @@ describe(@"transformTextAtRange with plain text", ^{
         [textView transformTextAtRange:NSMakeRange(0, 1) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:baseString];
         }];
-        expect(textView.text).to.equal(baseString);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(baseString);
+        });
     });
 
     it(@"should properly handle an empty string for transformed text", ^{
         [textView transformTextAtRange:NSMakeRange(0, 11) withTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return nil;
         }];
-        expect(textView.text).to.equal(@"rown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"rown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly ignore a nil block", ^{
@@ -108,7 +121,9 @@ describe(@"transformTextAtRange with attributed text", ^{
         for (NSUInteger i=0; i<[textView.attributedText length]; i++) {
             UIColor *fColor = [textView.attributedText attribute:NSForegroundColorAttributeName atIndex:i effectiveRange:NULL];
             if (i >= location && i < location + [replacementString length]) {
-                expect(fColor).to.equal([UIColor redColor]);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    expect(fColor).to.equal([UIColor redColor]);
+                });
             }
             else {
                 expect(fColor).to.beNil;
@@ -130,7 +145,9 @@ describe(@"transformTextAtRange with attributed text", ^{
         for (NSUInteger i=0; i<[textView.attributedText length]; i++) {
             UIColor *fColor = [textView.attributedText attribute:NSForegroundColorAttributeName atIndex:i effectiveRange:NULL];
             UIColor *expectColor = (i >= location && i < location + [replacementString length]) ? [UIColor redColor] : [UIColor greenColor];
-            expect(fColor).to.equal(expectColor);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                expect(fColor).to.equal(expectColor);
+            });
         }
     });
 
@@ -173,7 +190,9 @@ describe(@"transformSelectedTextWithTransformer", ^{
         [textView transformSelectedTextWithTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"#### TEST ####"];
         }];
-        expect(textView.text).to.equal(@"#### TEST #### quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"#### TEST #### quick brown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly transform selected text with a zero selection length", ^{
@@ -181,7 +200,9 @@ describe(@"transformSelectedTextWithTransformer", ^{
         [textView transformSelectedTextWithTransformer:^NSAttributedString *(__unused NSAttributedString *s) {
             return [[NSAttributedString alloc] initWithString:@"#### TEST ####"];
         }];
-        expect(textView.text).to.equal(@"The #### TEST ####quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The #### TEST ####quick brown fox jumps over the lazy dog");
+        });
     });
 });
 
@@ -200,17 +221,24 @@ describe(@"insertPlainText", ^{
 
     it(@"should properly insert text at beginning", ^{
         [textView insertPlainText:@"1234567890" location:0];
-        expect(textView.text).to.equal(@"1234567890The quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"1234567890The quick brown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly insert text in the middle", ^{
         [textView insertPlainText:@"HELLO_WORLD" location:4];
-        expect(textView.text).to.equal(@"The HELLO_WORLDquick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The HELLO_WORLDquick brown fox jumps over the lazy dog");
+        });
+        
     });
 
     it(@"should properly insert text at end", ^{
         [textView insertPlainText:@"*^*^*^*^*^" location:43];
-        expect(textView.text).to.equal(@"The quick brown fox jumps over the lazy dog*^*^*^*^*^");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The quick brown fox jumps over the lazy dog*^*^*^*^*^");
+        });
     });
 });
 
@@ -232,11 +260,16 @@ describe(@"insertAttributedText", ^{
     it(@"should properly insert attributed text at beginning", ^{
         NSUInteger location = 0;
         [textView insertAttributedText:insertString location:location];
-        expect(textView.text).to.equal(@"1234567890The quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"1234567890The quick brown fox jumps over the lazy dog");
+        });
+        
         for (NSUInteger i=0; i<[textView.attributedText length]; i++) {
             UIColor *bgColor = [textView.attributedText attribute:NSBackgroundColorAttributeName atIndex:i effectiveRange:NULL];
             if (i >= location && i < location + [insertString length]) {
-                expect(bgColor).to.equal([UIColor purpleColor]);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    expect(bgColor).to.equal([UIColor purpleColor]);
+                });
             }
             else {
                 expect(bgColor).to.beNil;
@@ -247,11 +280,15 @@ describe(@"insertAttributedText", ^{
     it(@"should properly insert text in the middle", ^{
         NSUInteger location = 4;
         [textView insertAttributedText:insertString location:location];
-        expect(textView.text).to.equal(@"The 1234567890quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The 1234567890quick brown fox jumps over the lazy dog");
+        });
         for (NSUInteger i=0; i<[textView.attributedText length]; i++) {
             UIColor *bgColor = [textView.attributedText attribute:NSBackgroundColorAttributeName atIndex:i effectiveRange:NULL];
             if (i >= location && i < location + [insertString length]) {
-                expect(bgColor).to.equal([UIColor purpleColor]);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    expect(bgColor).to.equal([UIColor purpleColor]);
+                });
             }
             else {
                 expect(bgColor).to.beNil;
@@ -262,7 +299,9 @@ describe(@"insertAttributedText", ^{
     it(@"should properly insert text at end", ^{
         NSUInteger location = 43;
         [textView insertAttributedText:insertString location:location];
-        expect(textView.text).to.equal(@"The quick brown fox jumps over the lazy dog1234567890");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The quick brown fox jumps over the lazy dog1234567890");
+        });
         for (NSUInteger i=0; i<[textView.attributedText length]; i++) {
             UIColor *bgColor = [textView.attributedText attribute:NSBackgroundColorAttributeName atIndex:i effectiveRange:NULL];
             if (i >= location && i <= location + [insertString length]) {
@@ -301,7 +340,10 @@ describe(@"insertTextAttachment", ^{
     it(@"should properly insert a text attachment", ^{
         [textView insertTextAttachment:attachment location:11];
         id object = [textView.attributedText attribute:NSAttachmentAttributeName atIndex:11 effectiveRange:NULL];
-        expect(object).to.equal(attachment);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(object).to.equal(attachment);
+        });
+        
     });
 
     it(@"should properly ignore a nil text attachment", ^{
@@ -332,17 +374,23 @@ describe(@"removeTextForRange", ^{
 
     it(@"should properly remove text at beginning", ^{
         [textView removeTextForRange:NSMakeRange(0, 2)];
-        expect(textView.text).to.equal(@"e quick brown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"e quick brown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly remove text in the middle", ^{
         [textView removeTextForRange:NSMakeRange(5, 7)];
-        expect(textView.text).to.equal(@"The qown fox jumps over the lazy dog");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The qown fox jumps over the lazy dog");
+        });
     });
 
     it(@"should properly remove text at end", ^{
         [textView removeTextForRange:NSMakeRange(31, 12)];
-        expect(textView.text).to.equal(@"The quick brown fox jumps over ");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            expect(textView.text).to.equal(@"The quick brown fox jumps over ");
+        });
     });
 
     it(@"should properly remove text for a zero-length range", ^{


### PR DESCRIPTION
Fix iOS QuickPath keyboard deadlock by scheduling text assignment in the main queue. 
There's also an open Apple feedback ticket,. [Open Radar](rdar://6828895)