### PR TITLE
Add flag to reverse order of mention selection delegate callbacks

### DIFF
--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -43,8 +43,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL) enableExperimentalDeadLockFix;
 + (BOOL) enableKoreanMentionsFix;
++ (BOOL) enableMentionSelectFix;
 + (void) setEnableExperimentalDeadLockFix:(BOOL)enabled;
 + (void) setEnableKoreanMentionsFix:(BOOL)enabled;
++ (void) setEnableMentionSelectFix:(BOOL)enabled;
 
 #pragma mark - Initialization
 

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -34,6 +34,7 @@
 
 static BOOL enableExperimentalDeadLockFix = NO;
 static BOOL enableKoreanMentionsFix = NO;
+static BOOL enableMentionSelectFix = NO;
 
 @implementation HKWTextView
 
@@ -49,6 +50,13 @@ static BOOL enableKoreanMentionsFix = NO;
 }
 + (void)setEnableKoreanMentionsFix:(BOOL)enabled {
     enableKoreanMentionsFix = enabled;
+}
+
++ (BOOL)enableMentionSelectFix {
+    return enableMentionSelectFix;
+}
++ (void)setEnableMentionSelectFix:(BOOL)enabled {
+    enableMentionSelectFix = enabled;
 }
 
 #pragma mark - Lifecycle

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -927,8 +927,15 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     mention.metadata = [entity entityMetadata];
     self.state = HKWMentionsCreationStateQuiescent;
     __strong __auto_type delegate = self.delegate;
-    [delegate createMention:mention startingLocation:self.startingLocation];
-    [delegate selected:entity atIndexPath:indexPath];
+
+    if (HKWTextView.enableMentionSelectFix) {
+        // Delegate selected callback should fire prior to creationMention which triggers textView callbacks
+        [delegate selected:entity atIndexPath:indexPath];
+        [delegate createMention:mention startingLocation:self.startingLocation];
+    } else {
+        [delegate createMention:mention startingLocation:self.startingLocation];
+        [delegate selected:entity atIndexPath:indexPath];
+    }
 }
 
 


### PR DESCRIPTION
Experimenting with a change where the `selected` callback always fires prior to any textView callbacks triggered by the `createMention` workflow. This allow the HKWTextView creator to act on the mention entity prior to receiving callbacks for the mention chooser view dismissal.