### PR TITLE
Trigger mention on whitespace removal rebased

### DIFF
--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -126,6 +126,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) BOOL inSingleLineViewportMode;
 
+/*!
+ String that saves the state of the text in the text view so that it can be accessed in the NSTextStorageDelegate, which will
+ already have deleted the character by the time it's trying to process said deletion
+ */
+@property (nonatomic, strong, readonly) NSString *textStateBeforeDeletion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -24,10 +24,7 @@
 @interface HKWTextView () <UITextViewDelegate, HKWAbstractionLayerDelegate, NSTextStorageDelegate>
 
 @property (nonatomic) NSMutableDictionary *simplePluginsDictionary;
-/*!
- String that saves the state of the text in the text view so that it can be accessed in the NSTextStorageDelegate, which will
- already have deleted the character by the time it's trying to process said deletion
- */
+
 @property (nonatomic, strong, readwrite) NSString *textStateBeforeDeletion;
 
 @end

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -270,9 +270,14 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
 
     __strong __auto_type delegate = self.delegate;
 
+    /**
+     For cases when mentions is triggered when whitespace between control character and word is deleted,
+     for example "@|John"('|'represents cursor), string buffer is not empty but mentions has to stop when control character is deleted.
+     Using isControlCharacterDeleted flag to decide control character deletion for such case.
+     */
     BOOL isControlCharacterDeleted = NO;
     if (deleteString.length == 1
-        &&[deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
+        && [deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
         && self.stringBuffer.length > 0
         && [self.stringBuffer characterAtIndex:self.stringBuffer.length - 1] != self.explicitSearchControlCharacter) {
         isControlCharacterDeleted = YES;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -165,9 +165,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
             }
     }
     // When whitespace is typed during mention creation state and previous character is control character
-    // then mention creation should be ended. e.g "@@ " will stop mention current creation.
-    const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
-    if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
+    // then mention creation should end. e.g "@@ " will stop mention current creation.
+    if (([self.stringBuffer length] == 0 || previousCharacterIsControl) && isWhitespace) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -164,8 +164,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    // When whitespace is typed during mention creation state and previous char is control character
-    // then metion creation should to stalled. e.g "@@ " will stop mention current creation.
+    // When whitespace is typed during mention creation state and previous character is control character
+    // then mention creation should be ended. e.g "@@ " will stop mention current creation.
     const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
     if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
         self.state = HKWMentionsCreationStateQuiescent;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 }
 
-- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted {
+- (void)stringDeleted:(NSString *)deleteString {
     // State transition
     NSAssert([deleteString length] > 0, @"Logic error: string to be deleted must not be empty.");
 
@@ -269,6 +269,14 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 
     __strong __auto_type delegate = self.delegate;
+
+    BOOL isControlCharacterDeleted = NO;
+    if (deleteString.length == 1
+        &&[deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
+        && self.stringBuffer.length > 0
+        && [self.stringBuffer characterAtIndex:self.stringBuffer.length - 1] != self.explicitSearchControlCharacter) {
+        isControlCharacterDeleted = YES;
+    }
 
     // Switch on the overall state
     switch (self.state) {

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -271,9 +271,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     __strong __auto_type delegate = self.delegate;
 
     /**
-     For cases when mentions is triggered when whitespace between control character and word is deleted,
-     for example "@|John"('|'represents cursor), string buffer is not empty but mentions has to stop when control character is deleted.
-     Using isControlCharacterDeleted flag to decide control character deletion for such case.
+     When mentions was originally triggered because the whitespace between a control character and a word was deleted,
+     the cursor is next to the control character (like "@|John", where '|' represents the cursor-state). If the user then deletes the control character,
+     the string buffer will not be empty (it will have "John" in it), but mentions has to stop, because control character is deleted.
+     We use the isControlCharacterDeleted flag to decide what to do in this case of control character deletion.
      */
     BOOL isControlCharacterDeleted = NO;
     if (deleteString.length == 1

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     return sm;
 }
 
-- (void)characterTyped:(unichar)c {
+- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl {
     BOOL isNewline = [[NSCharacterSet newlineCharacterSet] characterIsMember:c];
     BOOL isWhitespace = [[NSCharacterSet whitespaceCharacterSet] characterIsMember:c];
     __strong __auto_type delegate = self.delegate;
@@ -164,7 +164,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    if ([self.stringBuffer length] == 0 && isWhitespace) {
+    // When whitespace is typed during mention creation state and previous char is control character
+    // then metion creation should to stalled. e.g "@@ " will stop mention current creation.
+    const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
+    if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;
@@ -239,7 +242,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 }
 
-- (void)stringDeleted:(NSString *)deleteString {
+- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted {
     // State transition
     NSAssert([deleteString length] > 0, @"Logic error: string to be deleted must not be empty.");
 
@@ -276,6 +279,13 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
             // User not creating a mention right now
             return;
         case HKWMentionsCreationStateCreatingMention:
+            if (isControlCharacterDeleted) {
+                // When user deletes control character during mention creation state, then end mention creation.
+                self.state = HKWMentionsCreationStateQuiescent;
+                [delegate cancelMentionFromStartingLocation:self.startingLocation];
+                return;
+            }
+
             if (deleteStringIsTransient) {
                 // Delete was typed, but for some sort of transient state (e.g. keyboard suggestions); don't do anything
                 return;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     return sm;
 }
 
-- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl {
+- (void)characterTyped:(unichar)c {
     BOOL isNewline = [[NSCharacterSet newlineCharacterSet] characterIsMember:c];
     BOOL isWhitespace = [[NSCharacterSet whitespaceCharacterSet] characterIsMember:c];
     __strong __auto_type delegate = self.delegate;
@@ -164,9 +164,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    // When whitespace is typed during mention creation state and previous character is control character
-    // then mention creation should end. e.g "@@ " will stop mention current creation.
-    if (([self.stringBuffer length] == 0 || previousCharacterIsControl) && isWhitespace) {
+    if ([self.stringBuffer length] == 0 && isWhitespace) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -998,12 +998,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  is a space/newline preceding, but if this is changed then the state machine must be primed in case there
             //  is a mention right before the mention creation point.
             unichar stackC = deletedChar;
-
-            // This check is used to stop mention creation when control character triggering mentions is deleted.
-            BOOL isControlCharacterDeleted = (precedingChar == 0 || [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingChar])
-            && [self.controlCharacterSet characterIsMember:deletedChar];
-
-            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1] isControlCharacterDeleted:isControlCharacterDeleted];
+            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1]];
             // Get prior character to properly prime start detection state machine
             if (self.state == HKWMentionsStateQuiescent) {
                 // If we're in here, the mention creation ended (and by extension, we moved back to Quiescent)
@@ -1256,23 +1251,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             break;
-        case HKWMentionsStartDetectionStateCreatingMention: {
-            const BOOL precedingCharacterIsSeparator = [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingCharacter]
-            || [[NSCharacterSet punctuationCharacterSet] characterIsMember:precedingCharacter];
-            const BOOL deletedStringFirstCharacterIsControl = deletedString.length > 0
-            ? [self.controlCharacterSet characterIsMember:[deletedString characterAtIndex:0]]
-            : NO;
-
-            BOOL isControlCharacterDeleted = NO;
-            if (precedingCharacterIsSeparator && deletedStringFirstCharacterIsControl) {
-                isControlCharacterDeleted = YES;
-            }
-
-            [self.creationStateMachine stringDeleted:deletedString isControlCharacterDeleted:isControlCharacterDeleted];
+        case HKWMentionsStartDetectionStateCreatingMention:
+            [self.creationStateMachine stringDeleted:deletedString];
             self.nextSelectionChangeShouldBeIgnored = YES;
             self.nextInsertionShouldBeIgnored = YES;
             break;
-        }
         case HKWMentionsStateAboutToSelectMention:
         case HKWMentionsStateSelectedMention:
             [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingCharacter];

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -864,7 +864,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStartDetectionStateCreatingMention:
             // Inform the mentions creation state machine that a character was typed. Do not allow the double space to
             //  period auto-substitution while the user is creating a mention.
-            [self.creationStateMachine characterTyped:newChar previousCharacterIsControl:[self.controlCharacterSet characterIsMember:precedingChar]];
+            [self.creationStateMachine characterTyped:newChar];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -845,17 +845,19 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     BOOL isSecondSpace = (location > 1) && (precedingChar == ' ' && newChar == ' ');
     switch (self.state) {
         case HKWMentionsStateQuiescent: {
+            // Word following typed character would be used to trigger matching mentions menu when possible.
+            NSString *wordFollowingTypedCharacter;
             if (HKWTextView.enableKoreanMentionsFix) {
                 // Update the location of the selected range for this insertion here
                 // (since the text view will already be updated when utilizing the text storage delegate in the korean mentions fix)
                 // This should replace other settings of this range when the fix is ramped
                 parentTextView.selectedRange = NSMakeRange(location, parentTextView.selectedRange.length);
+                wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.textStateBeforeDeletion];
+            } else {
+                wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
             }
             // Inform the start detection state machine that a character was inserted. Also, override the double space
             //  to period auto-substitution if the substitution would place a period right after a preceding mention.
-
-            // Word following typed character would be used to trigger matching mentions menu when possible.
-            NSString *wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
             [self.startDetectionStateMachine characterTyped:newChar
                                         asInsertedCharacter:NO
                                           previousCharacter:precedingChar

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -844,7 +844,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStateQuiescent: {
             // Inform the start detection state machine that a character was inserted. Also, override the double space
             //  to period auto-substitution if the substitution would place a period right after a preceding mention.
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar];
+
+            // When control character is inserted before existing word in text view, then query mention with that word.
+            NSString *textAfterControlCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar queryMentionForText:textAfterControlCharacter];
             NSRange r;
             id mentionTwoPreceding = [self mentionAttributePrecedingLocation:(location-1) range:&r];
             BOOL shouldSuppress = (mentionTwoPreceding != nil) && (r.location + r.length == location-1);
@@ -858,7 +861,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStartDetectionStateCreatingMention:
             // Inform the mentions creation state machine that a character was typed. Do not allow the double space to
             //  period auto-substitution while the user is creating a mention.
-            [self.creationStateMachine characterTyped:newChar];
+            [self.creationStateMachine characterTyped:newChar previousCharacterIsControl:[self.controlCharacterSet characterIsMember:precedingChar]];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
@@ -870,7 +873,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  insert a new character and continue in the quiescent state. Do not allow auto-substitution.
             self.state = HKWMentionsStateQuiescent;
             [self resetCurrentMentionsData];
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar queryMentionForText:nil];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
@@ -892,7 +895,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:YES previousCharacter:precedingChar];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:YES previousCharacter:precedingChar queryMentionForText:nil];
             returnValue = NO;
             break;
         case HKWMentionsStateLosingFocus:
@@ -923,7 +926,9 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     switch (self.state) {
         case HKWMentionsStateQuiescent: {
             [self.startDetectionStateMachine deleteTypedCharacter:deletedChar
-                                  withCharacterNowPrecedingCursor:precedingChar];
+                                  withCharacterNowPrecedingCursor:precedingChar
+                                                         location:location
+                                                     textViewText:parentTextView.text];
             self.nextSelectionChangeShouldBeIgnored = YES;
 
             // Look for a mention
@@ -987,7 +992,17 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  is a space/newline preceding, but if this is changed then the state machine must be primed in case there
             //  is a mention right before the mention creation point.
             unichar stackC = deletedChar;
-            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1]];
+
+            // This check is used to stop mention creation when control character is deleted.
+            // Also check if second previous character is control, it YES then don't stop mention creation.
+            BOOL secondPreviousCaracterIsControl = NO;
+            if (location >= 1) {
+                unichar secondPreviousCharacter = [parentTextView.text characterAtIndex:location - 1];
+                secondPreviousCaracterIsControl = [self.controlCharacterSet characterIsMember:secondPreviousCharacter];
+            }
+            BOOL isControlCharacterDeleted = !secondPreviousCaracterIsControl && [self.controlCharacterSet characterIsMember:deletedChar];
+
+            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1] isControlCharacterDeleted:isControlCharacterDeleted];
             // Get prior character to properly prime start detection state machine
             if (self.state == HKWMentionsStateQuiescent) {
                 // If we're in here, the mention creation ended (and by extension, we moved back to Quiescent)
@@ -1134,8 +1149,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 self.previousSelectionRange = newSelectionRange;
                 self.previousTextLength = [[parentTextView text] length];
 
-                [self.startDetectionStateMachine characterTyped:[text characterAtIndex:0] asInsertedCharacter:YES previousCharacter:precedingChar];
-
+                [self.startDetectionStateMachine characterTyped:[text characterAtIndex:0] asInsertedCharacter:YES previousCharacter:precedingChar queryMentionForText:nil];
                 // Manually notify external delegate that the textView changed
                 id<HKWTextViewDelegate> externalDelegate = parentTextView.externalDelegate;
                 if ([externalDelegate respondsToSelector:@selector(textViewDidChange:)]) {
@@ -1238,11 +1252,22 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             break;
-        case HKWMentionsStartDetectionStateCreatingMention:
-            [self.creationStateMachine stringDeleted:deletedString];
+        case HKWMentionsStartDetectionStateCreatingMention: {
+            const BOOL precedingCharacterIsWhitepace = [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingCharacter];
+            const BOOL deletedStringFirstCharacterIsControl = deletedString.length > 0
+            ? [self.controlCharacterSet characterIsMember:[deletedString characterAtIndex:0]]
+            : NO;
+
+            BOOL isControlCharacterDeleted = NO;
+            if (precedingCharacterIsWhitepace && deletedStringFirstCharacterIsControl) {
+                isControlCharacterDeleted = YES;
+            }
+
+            [self.creationStateMachine stringDeleted:deletedString isControlCharacterDeleted:isControlCharacterDeleted];
             self.nextSelectionChangeShouldBeIgnored = YES;
             self.nextInsertionShouldBeIgnored = YES;
             break;
+        }
         case HKWMentionsStateAboutToSelectMention:
         case HKWMentionsStateSelectedMention:
             [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingCharacter];
@@ -1781,7 +1806,12 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     UIColor *parentColor = parentTextView.textColorSetByApp;
     NSAssert(self.mentionUnselectedAttributes != nil, @"Error! Mention attribute dictionaries should never be nil.");
     NSDictionary *unselectedAttributes = self.mentionUnselectedAttributes;
-    NSRange rangeToTransform = NSMakeRange(location, currentLocation - location);
+
+    // When control char is inserted before word and user select mention for that word,
+    // then we want to replace word after control char with mention text.
+    // e.g "hey @|john" will be replaced as "hey John Doe". '|' indicates cursor.
+    NSString *const wordAfterCurrentLocation = [HKWMentionsStartDetectionStateMachine wordAfterLocation:currentLocation text:parentTextView.text];
+    NSRange rangeToTransform = NSMakeRange(location, currentLocation + wordAfterCurrentLocation.length - location);
 
     /*
      When the textview text that matches the mention text is not the first part of the mention text,

--- a/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
@@ -203,12 +203,16 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
 
     switch (self.state) {
         case HKWMentionsStartDetectionStateQuiescentReady: {
+            // Mention can be triggered upon character deletion:
+            // 1. when deleted character location is greater than 1 -> When previous character is a control character and character before previous character is a separator.
+            // 2. when deleted character location is 1 -> If preceding character is a control character
+            // 3. when deleted character location is 0 -> Does not trigger mentions
             BOOL canCreateMention = NO;
             if (location > 1 && textViewText.length > location - 2) {
                 const unichar characterBeforePrecedingChar = [textViewText characterAtIndex:location - 2];
                 canCreateMention = [HKWMentionsStartDetectionStateMachine.separatorSet characterIsMember:characterBeforePrecedingChar]
                 && precedingCharacterType == CharacterTypeControlCharacter;
-            } else if (location > 0 && precedingCharacterType == CharacterTypeControlCharacter) {
+            } else if (precedingCharacterType == CharacterTypeControlCharacter) {
                 canCreateMention = YES;
             }
             // If user deletes white-space or separators between control character and word, then query mention with word next to whitepace.

--- a/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
@@ -206,7 +206,7 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
             // Mention can be triggered upon character deletion:
             // 1. when deleted character location is greater than 1 -> When previous character is a control character and character before previous character is a separator.
             // 2. when deleted character location is 1 -> If preceding character is a control character
-            // 3. when deleted character location is 0 -> Does not trigger mentions
+            // (NOTE: When deleted character location is 0, mentions is never triggered)
             BOOL canCreateMention = NO;
             if (location > 1 && textViewText.length > location - 2) {
                 const unichar characterBeforePrecedingChar = [textViewText characterAtIndex:location - 2];
@@ -271,7 +271,7 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
             self.charactersSinceLastWhitespace = 0;
             if (currentCharacterType == CharacterTypeSeparator || currentCharacterType == CharacterTypeControlCharacter) {
                 // The user moved the cursor to the beginning of the text region, or right after a newline or whitespace or punctuation
-                //  character. This puts the user in the ready state.
+                //  character or control character. This puts the user in the ready state.
                 self.state = HKWMentionsStartDetectionStateQuiescentReady;
             }
             else if (currentCharacterType == CharacterTypeNormal) {

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -128,7 +128,7 @@
 /*!
  Inform the state machine that a character or string was deleted from the text view.
  */
-- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted;
+- (void)stringDeleted:(NSString *)deleteString;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -117,7 +117,7 @@
 /*!
  Inform the state machine that a single character was typed by the user into the text view.
  */
-- (void)characterTyped:(unichar)c;
+- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl;
 
 /*!
  Inform the state machine that a valid string was inserted into the text view (no spaces, newlines, or forbidden
@@ -128,7 +128,7 @@
 /*!
  Inform the state machine that a character or string was deleted from the text view.
  */
-- (void)stringDeleted:(NSString *)deleteString;
+- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -117,7 +117,7 @@
 /*!
  Inform the state machine that a single character was typed by the user into the text view.
  */
-- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl;
+- (void)characterTyped:(unichar)c;
 
 /*!
  Inform the state machine that a valid string was inserted into the text view (no spaces, newlines, or forbidden

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -94,12 +94,12 @@
  Inform the state machine that a character was typed by the user into the text view.
  \param inserted    whether the character was already inserted into the text view's text buffer
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter;
+- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter queryMentionForText:(NSString *)queryMentionForText;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
  */
-- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar;
+- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar location:(NSUInteger)location textViewText:(NSString *)textViewText;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.
@@ -124,5 +124,10 @@
  Inform the state machine that the attached control view has reset it's state, and now represents the specified string
  */
 -(void) resetStateUsingString:(NSString *)string;
+
+/*!
+ Return characters after given location till whitespace is encountered.
+ */
++ (NSString *)wordAfterLocation:(NSUInteger)location text:(NSString *)text;
 
 @end

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -104,6 +104,10 @@ wordFollowingTypedCharacter:(NSString *)wordFollowingTypedCharacter;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
+ \param deletedChar                         Character to be deleted
+ \param precedingChar                       Character before character to be deleted
+ \param location                            Location of character to be deleted
+ \param textViewText                        Text displayed by text view
  */
 - (void)deleteTypedCharacter:(unichar)deletedChar
 withCharacterNowPrecedingCursor:(unichar)precedingChar

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -94,12 +94,15 @@
  Inform the state machine that a character was typed by the user into the text view.
  \param inserted    whether the character was already inserted into the text view's text buffer
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter queryMentionForText:(NSString *)queryMentionForText;
+- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter nextString:(NSString *)nextString;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
  */
-- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar location:(NSUInteger)location textViewText:(NSString *)textViewText;
+- (void)deleteTypedCharacter:(unichar)deletedChar
+withCharacterNowPrecedingCursor:(unichar)precedingChar
+                    location:(NSUInteger)location
+                textViewText:(NSString *)textViewText;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -92,9 +92,15 @@
 
 /*!
  Inform the state machine that a character was typed by the user into the text view.
- \param inserted    whether the character was already inserted into the text view's text buffer
+ \param c                                   Character typed
+ \param inserted                            Whether the character was already inserted into the text view's text buffer
+ \param previousCharacter                   Character preceding typed character
+ \param wordFollowingTypedCharacter         Word following the typed character
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter nextString:(NSString *)nextString;
+- (void)characterTyped:(unichar)c
+   asInsertedCharacter:(BOOL)inserted
+     previousCharacter:(unichar)previousCharacter
+wordFollowingTypedCharacter:(NSString *)wordFollowingTypedCharacter;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.


### PR DESCRIPTION
 Editing the mention should trigger the typeahead again
    
    - On removal of whitespace between control character and typed in string, it should trigger mention again
    - Updated state machine, to update the flow to trigger mention
    
    Reference PR https://github.com/aniyati/Hakawai/pull/1 view all conversation/back-forth and review comments