### PR TITLE
Fix "implicit conversion from enumeration type to different enumeration type" in HKWAbstractionLayer

### DIFF
--- a/Hakawai/Core/AbstractionLayer/HKWAbstractionLayer.m
+++ b/Hakawai/Core/AbstractionLayer/HKWAbstractionLayer.m
@@ -161,7 +161,7 @@ typedef NS_ENUM(NSInteger, HKWAbstractionLayerInputMode) {
 
     // State-related
     self.state = HKWAbstractionLayerStateQuiescent;
-    self.changeType = HKWAbstractionLayerMarkStateNone;
+    self.changeType = HKWAbstractionLayerChangeTypeNone;
     self.markState = HKWAbstractionLayerMarkStateNone;
     self.selectedRangeWhenTextWasLastSelected = (textView.selectedRange.length > 0
                                                  ? textView.selectedRange


### PR DESCRIPTION
Demo app compiles + all tests pass locally.