### PR TITLE
Move instance methods to classes because the cannot be in protocols

### DIFF
--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "7.2.9"
+  s.version      = "7.3.0"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "10.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.2.9" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.3.0" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "7.3.0"
+  s.version      = "7.3.1"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "10.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.3.0" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.3.1" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai/Mentions/HKWMentionsPlugin.h
+++ b/Hakawai/Mentions/HKWMentionsPlugin.h
@@ -166,45 +166,6 @@ typedef NS_ENUM(NSInteger, HKWMentionsPluginState) {
 
 @property (nonatomic, weak, nullable) id<HKWMentionsStateChangeDelegate> stateChangeDelegate;
 
-/*!
- Instantiate a mentions plug-in with the specified chooser mode, no control characters, and a default search length of
- 3 characters.
- */
-+ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode;
-
-/*!
- Instantiate a mentions plug-in with the specified chooser mode, control character set, and search length.
-
- \param controlCharacterSet    a \c NSCharacterSet containing the character or characters that should be used to begin
-                               an explicit mention, or nil if explicit mentions should not be enabled
- \param searchLength           the number of characters to wait before beginning an implicit mention, or 0 or a negative
-                               value if implicit mentions should not be enabled
- */
-+ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
-                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
-                                 searchLength:(NSInteger)searchLength;
-
-/*!
- Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, a color for
- unselected mentions text, and a background color and text color for selected mentions text.
- */
-+ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
-                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
-                                 searchLength:(NSInteger)searchLength
-                              unselectedColor:(UIColor *_Null_unspecified)unselectedColor
-                                selectedColor:(UIColor *_Null_unspecified)selectedColor
-                      selectedBackgroundColor:(UIColor *_Null_unspecified)selectedBackgroundColor;
-
-/*!
- Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, custom attributes
- to apply to unselected mentions, and custom attributes to apply to selected mentions.
- */
-+ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
-                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
-                                 searchLength:(NSInteger)searchLength
-                  unselectedMentionAttributes:(NSDictionary *_Null_unspecified)unselectedAttributes
-                    selectedMentionAttributes:(NSDictionary *_Null_unspecified)selectedAttributes;
-
 #pragma mark - API
 
 /*!

--- a/Hakawai/Mentions/HKWMentionsPluginV1.h
+++ b/Hakawai/Mentions/HKWMentionsPluginV1.h
@@ -33,6 +33,46 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HKWMentionsPluginV1 : NSObject <HKWMentionsPlugin>
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, no control characters, and a default search length of
+ 3 characters.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, and search length.
+
+ \param controlCharacterSet    a \c NSCharacterSet containing the character or characters that should be used to begin
+                               an explicit mention, or nil if explicit mentions should not be enabled
+ \param searchLength           the number of characters to wait before beginning an implicit mention, or 0 or a negative
+                               value if implicit mentions should not be enabled
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, a color for
+ unselected mentions text, and a background color and text color for selected mentions text.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength
+                              unselectedColor:(UIColor *_Null_unspecified)unselectedColor
+                                selectedColor:(UIColor *_Null_unspecified)selectedColor
+                      selectedBackgroundColor:(UIColor *_Null_unspecified)selectedBackgroundColor;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, custom attributes
+ to apply to unselected mentions, and custom attributes to apply to selected mentions.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength
+                  unselectedMentionAttributes:(NSDictionary *_Null_unspecified)unselectedAttributes
+                    selectedMentionAttributes:(NSDictionary *_Null_unspecified)selectedAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Hakawai/Mentions/HKWMentionsPluginV2.h
+++ b/Hakawai/Mentions/HKWMentionsPluginV2.h
@@ -12,6 +12,45 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface HKWMentionsPluginV2 : NSObject <HKWMentionsPlugin>
 
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, no control characters, and a default search length of
+ 3 characters.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, and search length.
+
+ \param controlCharacterSet    a \c NSCharacterSet containing the character or characters that should be used to begin
+                               an explicit mention, or nil if explicit mentions should not be enabled
+ \param searchLength           the number of characters to wait before beginning an implicit mention, or 0 or a negative
+                               value if implicit mentions should not be enabled
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, a color for
+ unselected mentions text, and a background color and text color for selected mentions text.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength
+                              unselectedColor:(UIColor *_Null_unspecified)unselectedColor
+                                selectedColor:(UIColor *_Null_unspecified)selectedColor
+                      selectedBackgroundColor:(UIColor *_Null_unspecified)selectedBackgroundColor;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, custom attributes
+ to apply to unselected mentions, and custom attributes to apply to selected mentions.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                 searchLength:(NSInteger)searchLength
+                  unselectedMentionAttributes:(NSDictionary *_Null_unspecified)unselectedAttributes
+                    selectedMentionAttributes:(NSDictionary *_Null_unspecified)selectedAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
In swift, instance methods in protocols aren't recognized and you can't instantiate a class via one. Moving these to respective v1/v2 header files to enable swift portability