### PR TITLE
Create typingAttributesSetByApp to restore textView typingAttributes

### DIFF
--- a/Hakawai/Core/HKWTextView+Plugins.h
+++ b/Hakawai/Core/HKWTextView+Plugins.h
@@ -186,4 +186,10 @@ typedef NS_ENUM(NSInteger, HKWAccessoryViewMode) {
  */
 @property (nonatomic, readonly) UIColor *textColorSetByApp;
 
+/*!
+ If the app explicitly set the text view's typingAttributes return the most recent attributes set by the app.
+ If the app never set the text color, return nil.
+ */
+@property (nonatomic, readonly) NSDictionary *typingAttributesSetByApp;
+
 @end

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -709,7 +709,7 @@ static BOOL enableMentionsCreationStateMachineV2 = NO;
     }
 }
 
-- (void)setTypingAttributes:(NSDictionary<NSAttributedStringKey,id> *)typingAttributes {
+- (void)setTypingAttributes:(NSDictionary *)typingAttributes {
     [super setTypingAttributes:typingAttributes];
     if (typingAttributes) {
         self.typingAttributesSetByApp = typingAttributes;

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -117,6 +117,7 @@ static BOOL enableMentionsCreationStateMachineV2 = NO;
 
     replacement.font = self.font;
     replacement.fontSetByApp = self.font;
+    replacement.typingAttributesSetByApp = self.typingAttributes;
 
     replacement.clearsOnInsertion = NO;
     replacement.selectable = self.selectable;
@@ -705,6 +706,13 @@ static BOOL enableMentionsCreationStateMachineV2 = NO;
     [super setFont:font];
     if (font) {
         self.fontSetByApp = font;
+    }
+}
+
+- (void)setTypingAttributes:(NSDictionary<NSAttributedStringKey,id> *)typingAttributes {
+    [super setTypingAttributes:typingAttributes];
+    if (typingAttributes) {
+        self.typingAttributesSetByApp = typingAttributes;
     }
 }
 

--- a/Hakawai/Core/_HKWTextView.h
+++ b/Hakawai/Core/_HKWTextView.h
@@ -108,9 +108,10 @@
 @property (nonatomic) BOOL overridingSpellChecking;
 
 
-#pragma mark - Other proeprties
+#pragma mark - Other properties
 
 @property (nonatomic, strong, readwrite) UIFont *fontSetByApp;
 @property (nonatomic, strong, readwrite) UIColor *textColorSetByApp;
+@property (nonatomic, strong, readwrite) NSDictionary *typingAttributesSetByApp;
 
 @end

--- a/Hakawai/Mentions/HKWMentionsPluginV1.m
+++ b/Hakawai/Mentions/HKWMentionsPluginV1.m
@@ -488,12 +488,19 @@
  dictionary and, if applicable, restoring default attributes from the parent text view.
  */
 - (NSDictionary *)typingAttributesByStrippingMentionAttributes:(NSDictionary *)originalAttributes {
+    __strong __auto_type parentTextView = self.parentTextView;
+    
+    // If we have the typing attibutes we don't need to try to rip out the selected/unselected attributes
+    if (parentTextView.typingAttributesSetByApp) {
+        return parentTextView.typingAttributesSetByApp;
+    }
+    
     NSMutableDictionary *d = [originalAttributes mutableCopy];
     for (NSString *key in self.mentionUnselectedAttributes) {
         [d removeObjectForKey:key];
     }
+    
     // Restore the font and/or text color, if the app set either explicitly at any point.
-    __strong __auto_type parentTextView = self.parentTextView;
     if (parentTextView.fontSetByApp) {
         d[NSFontAttributeName] = parentTextView.fontSetByApp;
     }


### PR DESCRIPTION
I was running into issues where after a mention is detected, my textView's `typingAttributes` are not used. 

Looking at the code, it appears that after inserting a mention, the `typingAttributes` get recreated via `stripCustomAttributesFromTypingAttributes`. This method takes the current `typingAttributes` and removes all keys that are also in `mentionUnselectedAttributes`. It then tries to recreate `typingAttributes` by using `fontSetByApp` and `textColorSetByApp`. 

My code never set these values, and instead was only using `typingAttributes`. After a mention was created, the font and foreground attributes would be removed by `stripCustomAttributesFromTypingAttributes`, leaving my textView with no `typingAttributes`.

This is a simple change to also keep track of `typingAttributesSetByApp`. If in `typingAttributesByStrippingMentionAttributes:` we see that `typingAttributesSetByApp` is non-nil, we return those. Otherwise we fall back on `fontSetByApp` and `textColorSetByApp`. 
