### PR TITLE
Prepend control characters to mention text

### DIFF
--- a/Hakawai.xcodeproj/project.pbxproj
+++ b/Hakawai.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		77004FD7B4A6E9EDAD723CA9 /* libPods-Hakawai.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6238CF1B85D9D08466AD7A9C /* libPods-Hakawai.a */; };
 		7B2F035424E366C300C98454 /* HKWMentionsPluginV1.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2F035024E366C200C98454 /* HKWMentionsPluginV1.m */; };
 		7B2F035524E366C300C98454 /* HKWMentionsPluginV2.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2F035324E366C300C98454 /* HKWMentionsPluginV2.m */; };
+		81453A84260A39A100BDA3F7 /* HKWExternalMentionConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 81453A83260A39A100BDA3F7 /* HKWExternalMentionConstants.m */; };
 		8B5E141025A313AA0044A675 /* HKWMentionsCreationStateMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B5E140E25A313AA0044A675 /* HKWMentionsCreationStateMachine.m */; };
 		9C65FBC81F607DEB004A9CB4 /* HKWLayoutManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C65FBC61F607DEB004A9CB4 /* HKWLayoutManagerTests.m */; };
 		9C65FBC91F607DEB004A9CB4 /* HKWMentionsPluginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C65FBC71F607DEB004A9CB4 /* HKWMentionsPluginTests.m */; };
@@ -84,6 +85,8 @@
 		7B2F035124E366C200C98454 /* HKWMentionsPluginV1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HKWMentionsPluginV1.h; path = Mentions/HKWMentionsPluginV1.h; sourceTree = "<group>"; };
 		7B2F035224E366C200C98454 /* HKWMentionsPluginV2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HKWMentionsPluginV2.h; path = Mentions/HKWMentionsPluginV2.h; sourceTree = "<group>"; };
 		7B2F035324E366C300C98454 /* HKWMentionsPluginV2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HKWMentionsPluginV2.m; path = Mentions/HKWMentionsPluginV2.m; sourceTree = "<group>"; };
+		81453A82260A39A100BDA3F7 /* HKWExternalMentionConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HKWExternalMentionConstants.h; sourceTree = "<group>"; };
+		81453A83260A39A100BDA3F7 /* HKWExternalMentionConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HKWExternalMentionConstants.m; sourceTree = "<group>"; };
 		8B5E140E25A313AA0044A675 /* HKWMentionsCreationStateMachine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HKWMentionsCreationStateMachine.m; path = Mentions/HKWMentionsCreationStateMachine.m; sourceTree = "<group>"; };
 		8BF83FE125CB210500B856F8 /* HKWMentionsCreationStateMachineDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HKWMentionsCreationStateMachineDelegate.h; path = Mentions/HKWMentionsCreationStateMachineDelegate.h; sourceTree = "<group>"; };
 		91FF0C96BCF39C932C98A368 /* Pods-HakawaiTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HakawaiTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HakawaiTests/Pods-HakawaiTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -274,6 +277,8 @@
 				7B2F035024E366C200C98454 /* HKWMentionsPluginV1.m */,
 				7B2F035224E366C200C98454 /* HKWMentionsPluginV2.h */,
 				7B2F035324E366C300C98454 /* HKWMentionsPluginV2.m */,
+				81453A82260A39A100BDA3F7 /* HKWExternalMentionConstants.h */,
+				81453A83260A39A100BDA3F7 /* HKWExternalMentionConstants.m */,
 			);
 			name = Mentions;
 			sourceTree = "<group>";
@@ -530,6 +535,7 @@
 				E11DF8D119EC8DA30072F4AD /* HKWTextView+TextTransformation.m in Sources */,
 				E1B3088619A2C0D60096DE0E /* HKWLayoutManager.m in Sources */,
 				E1B3088219A2C0D60096DE0E /* HKWTextView+Extras.m in Sources */,
+				81453A84260A39A100BDA3F7 /* HKWExternalMentionConstants.m in Sources */,
 				7B2F035424E366C300C98454 /* HKWMentionsPluginV1.m in Sources */,
 				7B2F035524E366C300C98454 /* HKWMentionsPluginV2.m in Sources */,
 				E1B308A719A2C21A0096DE0E /* HKWDefaultChooserView.m in Sources */,

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -43,8 +43,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL) enableMentionsPluginV2;
 + (BOOL) directlyUpdateQueryWithCustomDelegate;
++ (BOOL) enableControlCharactersToPrepend;
 + (void) setEnableMentionsPluginV2:(BOOL)enabled;
 + (void) setDirectlyUpdateQueryWithCustomDelegate:(BOOL)enabled;
++ (void) setEnableControlCharactersToPrepend:(BOOL)enabled;
 
 #pragma mark - Initialization
 

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -42,6 +42,7 @@
 
 static BOOL enableMentionsPluginV2 = NO;
 static BOOL directlyUpdateQueryWithCustomDelegate = NO;
+static BOOL enableControlCharactersToPrepend = NO;
 
 @implementation HKWTextView
 
@@ -59,6 +60,14 @@ static BOOL directlyUpdateQueryWithCustomDelegate = NO;
 
 + (void)setDirectlyUpdateQueryWithCustomDelegate:(BOOL)enabled {
     directlyUpdateQueryWithCustomDelegate = enabled;
+}
+
++ (BOOL)enableControlCharactersToPrepend {
+    return enableControlCharactersToPrepend;
+}
+
++ (void)setEnableControlCharactersToPrepend:(BOOL)enabled {
+    enableControlCharactersToPrepend = enabled;
 }
 
 #pragma mark - Lifecycle

--- a/Hakawai/HKWExternalMentionConstants.h
+++ b/Hakawai/HKWExternalMentionConstants.h
@@ -1,0 +1,23 @@
+//
+//  HKWExternalMentionConstants.h
+//  Hakawai
+//
+//  Created by Chen Yuan on 3/23/21.
+//  Copyright © 2021 LinkedIn. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HKWExternalMentionConstants : NSObject
+
+/**
+ Character set for at symbols to prepend to mention text, including @, ＠ (Japanese).
+ NOTE: This is for the ease of library consumers, not for use inside the library
+ */
+@property (nonatomic, class, nonnull, readonly) NSCharacterSet *atSymbols;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Hakawai/HKWExternalMentionConstants.m
+++ b/Hakawai/HKWExternalMentionConstants.m
@@ -1,0 +1,17 @@
+//
+//  HKWExternalMentionConstants.m
+//  Hakawai
+//
+//  Created by Chen Yuan on 3/23/21.
+//  Copyright © 2021 LinkedIn. All rights reserved.
+//
+
+#import "HKWExternalMentionConstants.h"
+
+@implementation HKWExternalMentionConstants
+
++ (nonnull NSCharacterSet *)atSymbols {
+    return [NSCharacterSet characterSetWithCharactersInString:@"@＠"];
+}
+
+@end

--- a/Hakawai/Mentions/HKWMentionsPluginV2.h
+++ b/Hakawai/Mentions/HKWMentionsPluginV2.h
@@ -27,8 +27,16 @@ NS_ASSUME_NONNULL_BEGIN
                                value if implicit mentions should not be enabled
  */
 + (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
-                            controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
-                                 searchLength:(NSInteger)searchLength;
+                                    controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                         searchLength:(NSInteger)searchLength;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, control characters to prepend, search length
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                                    controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                           controlCharactersToPrepend:(NSCharacterSet *_Null_unspecified)controlCharactersToPrepend
+                                         searchLength:(NSInteger)searchLength;
 
 /*!
  Instantiate a mentions plug-in with the specified chooser mode, control character set, search length, a color for
@@ -47,6 +55,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
                                     controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                                         searchLength:(NSInteger)searchLength
+                       unhighlightedMentionAttributes:(NSDictionary *_Null_unspecified)unhighlightedAttributes
+                         highlightedMentionAttributes:(NSDictionary *_Null_unspecified)highlightedAttributes;
+
+/*!
+ Instantiate a mentions plug-in with the specified chooser mode, control character set, control characters to prepend, search length, custom attributes
+ to apply to unselected mentions, and custom attributes to apply to selected mentions.
+ */
++ (nonnull instancetype)mentionsPluginWithChooserMode:(HKWMentionsChooserPositionMode)mode
+                                    controlCharacters:(NSCharacterSet *_Null_unspecified)controlCharacterSet
+                           controlCharactersToPrepend:(NSCharacterSet *_Null_unspecified)controlCharactersToPrepend
                                          searchLength:(NSInteger)searchLength
                        unhighlightedMentionAttributes:(NSDictionary *_Null_unspecified)unhighlightedAttributes
                          highlightedMentionAttributes:(NSDictionary *_Null_unspecified)highlightedAttributes;

--- a/HakawaiDemo/HakawaiDemo/MentionsDemoViewController.m
+++ b/HakawaiDemo/HakawaiDemo/MentionsDemoViewController.m
@@ -52,6 +52,8 @@ BOOL HKW_systemVersionIsAtLeast(NSString *version);
         NSCharacterSet *controlCharacters = [NSCharacterSet characterSetWithCharactersInString:@"@+＠"];
         // The user may also begin a mention by typing three characters (set searchLength to 0 to disable)
         id<HKWMentionsPlugin> mentionsPlugin;
+        [HKWTextView setEnableMentionsPluginV2:YES];
+        [HKWTextView setEnableControlCharactersToPrepend:YES];
         if (HKWTextView.enableMentionsPluginV2) {
             mentionsPlugin = [HKWMentionsPluginV2 mentionsPluginWithChooserMode:mode
                                                               controlCharacters:controlCharacters


### PR DESCRIPTION
When the user taps "@Chen" and selects entity "Chen Yuan", currently the highlighted mention text in the text view is "Chen Yuan". This PR is to implement the feature to prepend control character ('@') to mention entity text. Then the text view will display "@Chen Yuan".

The feature is implemented in the following steps:

1. Add a new parameter in HKWMentionsPluginV2's initializer to take in an NSCharacterSet of control characters to be prepended. Also add a class property for default at symbols, including English character (@) and Japanese character (＠).

2. When creating a new MentionsAttribue from the state machine, we check if the mention is triggered by a prepend-able control character, and if so, modify the text in the MentionsAttrirbute to include that control character at the beginning.  With this approach, we don't need to modify `- (NSArray *)mentions` and `- (void)addMention:(HKWMentionsAttribute *)mention` functions.

3. Add unit tests to verify the mention plugin's behaviors on different prepend control character sets, and do manual tests with English/Arabic/Japanese.

Below are the demo videos of English and Arabic.

https://user-images.githubusercontent.com/5710914/112066951-a4daca00-8b3d-11eb-8eaf-d27c9fa2f572.mov

https://user-images.githubusercontent.com/5710914/112066953-a4daca00-8b3d-11eb-8420-13cb9b73af39.mov

Demo for moving cursor:

https://user-images.githubusercontent.com/5710914/112177424-478f5900-8bcf-11eb-89d4-c792c79aec71.mov

