### PR TITLE
Fixed possible range mutation of the same attribute

### DIFF
--- a/Hakawai/Mentions/HKWMentionsPluginV2.m
+++ b/Hakawai/Mentions/HKWMentionsPluginV2.m
@@ -298,7 +298,8 @@ static int MAX_MENTION_QUERY_LENGTH = 100;
                                                          methods provided to work with mentions attributes.");
                                                   continue;
                                               }
-                                              HKWMentionsAttribute *attributeData = (HKWMentionsAttribute *)[object mutableCopy];
+                                              HKWMentionsAttribute *attribute = (HKWMentionsAttribute *)object;
+                                              HKWMentionsAttribute *attributeData = [HKWMentionsAttribute mentionWithText:attribute.mentionText identifier:attribute.entityIdentifier];
                                               attributeData.range = range;
                                               [buffer addObject:attributeData];
                                           }


### PR DESCRIPTION
`UITextView` can split an `NSAttributedString` and set new `font` attribute if some substring has a different language which needs another font (for example when the mention include both English and Korean, the Korean substring will have another `font` attribute then the default one set to that `UITextView`).
After the "split", each substring still had the same pointer to the same `HKWMentionsAttribute`, which repeatedly changed its `range` to the latest, and then made the `buffer` include the same `HKWMentionsAttribute` pointer multiple times and prevented access to all mention attributes.

Here I just created a new attribute and set the range to it, so at least we can iterate all ranges and decide if we want to merge or not, depending on the use case.