### PR TITLE
Update azure-pipelines.yml to macOS-11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
     - master
 
 pool:
-  vmImage: macOS-10.14
+  vmImage: macOS-11
   demands: xcode
 
 variables:


### PR DESCRIPTION
* `macOS-10.14` is deprecated according to https://github.com/actions/runner-images/issues/5583 so we're updating to `macOS-11` in `azure-pipelines.yml`